### PR TITLE
Setting up the tipi data dir during setup

### DIFF
--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -25,18 +25,18 @@ jobs:
 
           # Test install succeeeded 
           pathsToTest=(/usr/local/bin/tipi 
-              ~/.tipi/clang/*/bin/clang
-              ~/.tipi/cmake/*/bin/cmake
-              ~/.tipi/emsdk/*/emsdk
-              ~/.tipi/environments/*/xcode.cmake
-              ~/.tipi/go/*/bin/go
-              ~/.tipi/jdk/*/Contents/Home/bin/jar
-              ~/.tipi/nodejs/*/bin/node
-              ~/.tipi/openapi/*/openapi-generator-cli-5.1.1.jar
-              ~/.tipi/openapi-generator-script/*/openapi-generator-cli 
-              ~/.tipi/platform/*/cmake/projects/Poco/hunter.cmake
-              ~/.tipi/python/*/bin/python
-              ~/.tipi/file-sync/*/pysearpc/client.py)
+             /usr/local/share/.tipi/clang/*/bin/clang
+             /usr/local/share/.tipi/cmake/*/bin/cmake
+             /usr/local/share/.tipi/emsdk/*/emsdk
+             /usr/local/share/.tipi/environments/*/xcode.cmake
+             /usr/local/share/.tipi/go/*/bin/go
+             /usr/local/share/.tipi/jdk/*/Contents/Home/bin/jar
+             /usr/local/share/.tipi/nodejs/*/bin/node
+             /usr/local/share/.tipi/openapi/*/openapi-generator-cli-5.1.1.jar
+             /usr/local/share/.tipi/openapi-generator-script/*/openapi-generator-cli 
+             /usr/local/share/.tipi/platform/*/cmake/projects/Poco/hunter.cmake
+             /usr/local/share/.tipi/python/*/bin/python
+             /usr/local/share/.tipi/elfshaker/*/elfshaker)
           
           for element in "${pathsToTest[@]}"
           do
@@ -59,9 +59,9 @@ jobs:
 
           # Test install succeeeded 
           pathsToTest=(/usr/local/bin/tipi 
-              ~/.tipi/environments/*/xcode.cmake
-              ~/.tipi/python/*/bin/python
-              ~/.tipi/file-sync/*/pysearpc/client.py)
+             /usr/local/share/.tipi/environments/*/xcode.cmake
+             /usr/local/share/.tipi/python/*/bin/python
+            /usr/local/share/.tipi/elfshaker/*/elfshaker)
 
           for element in "${pathsToTest[@]}"
           do
@@ -70,10 +70,10 @@ jobs:
           done
     
           pathsToTest_negative=(~/.tipi/clang/*/bin/clang
-              ~/.tipi/cmake/*/bin/cmake
-              ~/.tipi/emsdk/*/emsdk
-              ~/.tipi/go/*/bin/go
-              ~/.tipi/jdk/*/bin/jar)
+             /usr/local/share/.tipi/cmake/*/bin/cmake
+             /usr/local/share/.tipi/emsdk/*/emsdk
+             /usr/local/share/.tipi/go/*/bin/go
+             /usr/local/share/.tipi/jdk/*/bin/jar)
 
           for element in "${pathsToTest_negative[@]}"
           do
@@ -99,17 +99,17 @@ jobs:
           # Test install succeeeded 
 
           pathsToTest=(/usr/local/bin/tipi 
-              ~/.tipi/clang/*/bin/clang
-              ~/.tipi/cmake/*/bin/cmake
-              ~/.tipi/emsdk/*/emsdk
-              ~/.tipi/environments/*/xcode.cmake
-              ~/.tipi/go/*/bin/go
-              ~/.tipi/jdk/*/bin/jar
-              ~/.tipi/nodejs/*/bin/node
-              ~/.tipi/openapi/*/openapi-generator-cli-5.1.1.jar
-              ~/.tipi/openapi-generator-script/*/openapi-generator-cli 
-              ~/.tipi/platform/*/cmake/projects/Poco/hunter.cmake
-              ~/.tipi/file-sync/*/pysearpc/client.py)
+             /usr/local/share/.tipi/clang/*/bin/clang
+             /usr/local/share/.tipi/cmake/*/bin/cmake
+             /usr/local/share/.tipi/emsdk/*/emsdk
+             /usr/local/share/.tipi/environments/*/xcode.cmake
+             /usr/local/share/.tipi/go/*/bin/go
+             /usr/local/share/.tipi/jdk/*/bin/jar
+             /usr/local/share/.tipi/nodejs/*/bin/node
+             /usr/local/share/.tipi/openapi/*/openapi-generator-cli-5.1.1.jar
+             /usr/local/share/.tipi/openapi-generator-script/*/openapi-generator-cli 
+             /usr/local/share/.tipi/platform/*/cmake/projects/Poco/hunter.cmake
+             /usr/local/share/.tipi/elfshaker/*/elfshaker)
           
           for element in "${pathsToTest[@]}"
           do
@@ -141,8 +141,8 @@ jobs:
           
           # Test install succeeeded 
           pathsToTest=(/usr/local/bin/tipi 
-              ~/.tipi/environments/*/xcode.cmake
-              ~/.tipi/file-sync/*/pysearpc/client.py)
+             /usr/local/share/.tipi/environments/*/xcode.cmake
+             /usr/local/share/.tipi/elfshaker/*/elfshaker)
           
           for element in "${pathsToTest[@]}"
           do
@@ -151,10 +151,10 @@ jobs:
           done
 
           pathsToTest_negative=(~/.tipi/clang/*/bin/clang
-              ~/.tipi/cmake/*/bin/cmake
-              ~/.tipi/emsdk/*/emsdk
-              ~/.tipi/go/*/bin/go
-              ~/.tipi/jdk/*/Contents/Home/bin/jar)
+             /usr/local/share/.tipi/cmake/*/bin/cmake
+             /usr/local/share/.tipi/emsdk/*/emsdk
+             /usr/local/share/.tipi/go/*/bin/go
+             /usr/local/share/.tipi/jdk/*/Contents/Home/bin/jar)
 
           for element in "${pathsToTest_negative[@]}"
           do
@@ -261,7 +261,7 @@ jobs:
             "C:\.tipi\perl\*\README.txt"  
             "C:\.tipi\platform\*\cmake\projects\Poco\hunter.cmake"  
             "C:\.tipi\python\*\python.exe"  
-            "C:\.tipi\file-sync\*\pysearpc\client.py"  
+            "C:\.tipi\elfshaker\*\elfshaker.exe"  
           )
 
           $success = $true
@@ -318,7 +318,7 @@ jobs:
             "C:\.tipi\environments\*\xcode.cmake" 
             "C:\.tipi\openssh\*\ssh.exe"
             "C:\.tipi\python\*\python.exe"  
-            "C:\.tipi\file-sync\*\pysearpc\client.py"  
+            "C:\.tipi\elfshaker\*\elfshaker.exe"  
           )
 
           $success = $true
@@ -459,7 +459,7 @@ jobs:
             "C:\.tipi\environments\*\xcode.cmake" 
             "C:\.tipi\openssh\*\ssh.exe"
             "C:\.tipi\python\*\python.exe"  
-            "C:\.tipi\file-sync\*\pysearpc\client.py"  
+            "C:\.tipi\elfshaker\*\elfshaker.exe"  
           )
 
           $success = $true
@@ -516,17 +516,17 @@ jobs:
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/${script_source}/install/install_for_macos_linux.sh)"
           # Test install succeeeded 
           pathsToTest=(/usr/local/bin/tipi 
-              ~/.tipi/clang/*/bin/clang
-              ~/.tipi/cmake/*/bin/cmake
-              ~/.tipi/emsdk/*/emsdk
-              ~/.tipi/environments/*/xcode.cmake
-              ~/.tipi/go/*/bin/go
-              ~/.tipi/jdk/*/bin/jar
-              ~/.tipi/nodejs/*/bin/node
-              ~/.tipi/openapi/*/openapi-generator-cli-5.1.1.jar
-              ~/.tipi/openapi-generator-script/*/openapi-generator-cli 
-              ~/.tipi/platform/*/cmake/projects/Poco/hunter.cmake
-              ~/.tipi/file-sync/*/pysearpc/client.py)
+             /usr/local/share/.tipi/clang/*/bin/clang
+             /usr/local/share/.tipi/cmake/*/bin/cmake
+             /usr/local/share/.tipi/emsdk/*/emsdk
+             /usr/local/share/.tipi/environments/*/xcode.cmake
+             /usr/local/share/.tipi/go/*/bin/go
+             /usr/local/share/.tipi/jdk/*/bin/jar
+             /usr/local/share/.tipi/nodejs/*/bin/node
+             /usr/local/share/.tipi/openapi/*/openapi-generator-cli-5.1.1.jar
+             /usr/local/share/.tipi/openapi-generator-script/*/openapi-generator-cli 
+             /usr/local/share/.tipi/platform/*/cmake/projects/Poco/hunter.cmake
+             /usr/local/share/.tipi/elfshaker/*/elfshaker)
 
           for element in "${pathsToTest[@]}"
           do
@@ -556,8 +556,8 @@ jobs:
           
           # Test install succeeeded 
           pathsToTest=(/usr/local/bin/tipi 
-              ~/.tipi/environments/*/xcode.cmake
-              ~/.tipi/file-sync/*/pysearpc/client.py)
+             /usr/local/share/.tipi/environments/*/xcode.cmake
+             /usr/local/share/.tipi/elfshaker/*/elfshaker)
 
           for element in "${pathsToTest[@]}"
           do
@@ -566,10 +566,10 @@ jobs:
           done
 
           pathsToTest_negative=(~/.tipi/clang/*/bin/clang
-              ~/.tipi/cmake/*/bin/cmake
-              ~/.tipi/emsdk/*/emsdk
-              ~/.tipi/go/*/bin/go
-              ~/.tipi/jdk/*/bin/jar)
+             /usr/local/share/.tipi/cmake/*/bin/cmake
+             /usr/local/share/.tipi/emsdk/*/emsdk
+             /usr/local/share/.tipi/go/*/bin/go
+             /usr/local/share/.tipi/jdk/*/bin/jar)
 
           for element in "${pathsToTest_negative[@]}"
           do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # tipi.build cli : CHANGELOG
 
+## v0.0.35 - codename Yodeling Yak @ CppCon 🤠 
+
+### Feature
+  - Remote build file synchronization fully rewritten
+  - Introducing the gitpiler 
+  - Global Build Cache
+  - Self hosted runners
+  - live build 
+
+##### Archives Checksums
+tipi-v0.0.35-windows-win64.zip:86EC51AB365C8D686DF87F77809706AE171421E3
+tipi-v0.0.35-linux-x86_64.zip:DF5FC190EBA8C5E8A418107984072DD1AB082F72
+tipi-v0.0.35-macOS.zip:B620BD356DEEDE35144B9AD5A0D480726C24AAA8
+
 ## v0.0.34 - codename Xenodochial Xoloitzcuintli 🐶
 
 ### Feature

--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -94,6 +94,11 @@ if [ $? -eq 0 ]; then
     info "Cleaning up temporary download"
     rm $TMP_DOWNLOAD_PATH
 
+    TIPI_DATA_DIR=/usr/local/share/.tipi
+    info "Setting up tipi's local storage in $TIPI_DATA_DIR"
+    $PRIV_ELEV_CMD mkdir -p $TIPI_DATA_DIR
+    $PRIV_ELEV_CMD chown -R ${USER:=$(/usr/bin/id -run)} $TIPI_DATA_DIR
+
     info "Provisioning included tools."
     $INSTALL_FOLDER/bin/tipi -v --dont-upgrade run echo "[INFO] Shipping tools done"
     if [ $? -eq 0 ]; then

--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -32,7 +32,7 @@ should_install_unzip() {
 # impl.
 ### 
 
-VERSION="${TIPI_INSTALL_VERSION:-v0.0.34}"
+VERSION="${TIPI_INSTALL_VERSION:-v0.0.35}"
 INSTALL_FOLDER=/usr/local
 
 if [[ -z "${TIPI_INSTALL_SOURCE}" ]]; then

--- a/install/install_for_windows.ps1
+++ b/install/install_for_windows.ps1
@@ -58,7 +58,7 @@ if([bool]::TryParse($env:TIPI_INSTALL_SYSTEM, [ref]$system_install)) {
 }
 
 if ([string]::IsNullOrEmpty($version_to_use)) {
-    $version_to_use="v0.0.34"
+    $version_to_use="v0.0.35"
 }
 
 if ([string]::IsNullOrEmpty($INSTALL_FOLDER)) {


### PR DESCRIPTION
Additions to the linux install script to ensure `/usr/local/share/.tipi` exists and is writable for the user