### PR TITLE
macOS ARM64 M1 and M2 support via Rosetta

### DIFF
--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -32,7 +32,7 @@ should_install_unzip() {
 # impl.
 ### 
 
-VERSION="${TIPI_INSTALL_VERSION:-v0.0.45}"
+VERSION="${TIPI_INSTALL_VERSION:-v0.0.50}"
 INSTALL_FOLDER=/usr/local
 
 if [[ -z "${TIPI_INSTALL_SOURCE}" ]]; then

--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -39,13 +39,6 @@ if [[ -z "${TIPI_INSTALL_SOURCE}" ]]; then
   if [ "$(uname)" == "Linux" ]; then
     TIPI_URL="https://github.com/tipi-build/cli/releases/download/$VERSION/tipi-$VERSION-linux-x86_64.zip" 
   elif [ "$(uname)" == "Darwin" ]; then
-
-    # test for M1/M2 
-    arch="$(sysctl -n machdep.cpu.brand_string)" # should output "Apple M(1|2).*" 
-    if [[ $(uname -m) == 'arm64' ]]; then
-      abort "Tipi does currently not support Apple Silicon. We're working hard on changing this asap. Stay tuned!"
-    fi
-
     TIPI_URL="https://github.com/tipi-build/cli/releases/download/$VERSION/tipi-$VERSION-macOS.zip"
   fi
 else

--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -43,7 +43,7 @@ if [[ -z "${TIPI_INSTALL_SOURCE}" ]]; then
 
     # test for M1/M2 
     if [[ $(uname -m) == 'arm64' ]]; then
-      info "Tipi requires rosetta to run on Apple ARM Silicon. Please confirm the Apple License Agreement." 
+      info "Tipi requires rosetta to run on Apple ARM Silicon. Launching installation, if you disagree with the Apple Rosetta license press Ctrl-C." 
       $PRIV_ELEV_CMD softwareupdate --install-rosetta --agree-to-license
     fi
 

--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -40,6 +40,13 @@ if [[ -z "${TIPI_INSTALL_SOURCE}" ]]; then
     TIPI_URL="https://github.com/tipi-build/cli/releases/download/$VERSION/tipi-$VERSION-linux-x86_64.zip" 
   elif [ "$(uname)" == "Darwin" ]; then
     TIPI_URL="https://github.com/tipi-build/cli/releases/download/$VERSION/tipi-$VERSION-macOS.zip"
+
+    # test for M1/M2 
+    if [[ $(uname -m) == 'arm64' ]]; then
+      info "Tipi requires rosetta to run on Apple ARM Silicon. Please confirm the Apple License Agreement." 
+      softwareupdate --install-rosetta
+    fi
+
   fi
 else
   TIPI_URL="${TIPI_INSTALL_SOURCE}"

--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -44,7 +44,7 @@ if [[ -z "${TIPI_INSTALL_SOURCE}" ]]; then
     # test for M1/M2 
     if [[ $(uname -m) == 'arm64' ]]; then
       info "Tipi requires rosetta to run on Apple ARM Silicon. Please confirm the Apple License Agreement." 
-      softwareupdate --install-rosetta
+      $PRIV_ELEV_CMD softwareupdate --install-rosetta --agree-to-license
     fi
 
   fi


### PR DESCRIPTION
This PR generalizes support of tipi on macOS M1 and M2 via Rosetta.

To be merged as we release the next version integrating https://github.com/nxxm/nxxm-src/pull/1125