### PR TITLE
:mag: fix the install tests for python as we now only have a python3 named binary

### DIFF
--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -35,7 +35,7 @@ jobs:
              /usr/local/share/.tipi/openapi/*/openapi-generator-cli-5.1.1.jar
              /usr/local/share/.tipi/openapi-generator-script/*/openapi-generator-cli 
              /usr/local/share/.tipi/platform/*/cmake/projects/Poco/hunter.cmake
-             /usr/local/share/.tipi/python/*/bin/python
+             /usr/local/share/.tipi/python/*/bin/python3
              /usr/local/share/.tipi/elfshaker/*/elfshaker)
           
           for element in "${pathsToTest[@]}"
@@ -60,7 +60,7 @@ jobs:
           # Test install succeeeded 
           pathsToTest=(/usr/local/bin/tipi 
              /usr/local/share/.tipi/environments/*/xcode.cmake
-             /usr/local/share/.tipi/python/*/bin/python
+             /usr/local/share/.tipi/python/*/bin/python3
             /usr/local/share/.tipi/elfshaker/*/elfshaker)
 
           for element in "${pathsToTest[@]}"


### PR DESCRIPTION
The tests crashed on master tonight https://github.com/tipi-build/cli/actions/runs/6153075477/job/16696339588

This is due to the check made for "python" existence, which is now python3.