### PR TITLE
[WIP] ⚙️ setup script to use withing docker containers build processes 

### DIFF
--- a/install/container/centos.sh
+++ b/install/container/centos.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# tipi docker setup script for centos
+# Copyright 2024 - tipi technologies Ltd (Zürich)
+
+export SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+yum makecache \
+ && yum install -y libnsl sudo ca-certificates openssh-server openssh-clients util-linux-ng util-linux-user libuser python3 cmake3 \
+ && yum groupinstall -y 'Development Tools' \
+ && yum install perl-IPC-Cmd # OpenSSL 3 build system requires this
+
+trust dump --filter "pkcs11:id=%c4%a7%b1%a4%7b%2c%71%fa%db%e1%4b%90%75%ff%c4%15%60%85%89%10" | openssl x509 | sudo tee /etc/pki/ca-trust/source/blacklist/DST-Root-CA-X3.pem
+update-ca-trust extract
+# Remove it, when https://github.com/nxxm/nxxm-src/pull/1261 is released
+cp /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/cert.pem
+cp /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt
+
+# Enable ssh
+ssh-keygen -A
+systemctl enable sshd
+rm /run/nologin # allow non root users to login
+
+# User id 1001 is the user on Github Default Runner and 123 is the group of the files on the Github Default Runner
+groupadd --gid 123 gh-actions-group
+groupadd --gid 124 wine
+
+groupadd --gid 1001 tipi && adduser --system --uid 1001 --gid 1001 -G gh-actions-group,wine,wheel --create-home --home-dir /home/tipi tipi \
+  && echo 'tipi ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/tipi
+
+groupadd --gid 1000 tipi-large && adduser --system --uid 1000 --gid 1000 -G gh-actions-group,wine,wheel --create-home --home-dir /home/tipi-large tipi-large \
+  && echo 'tipi-large ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/tipi-large
+
+# https://docs.engflow.com/re/client/bazel-first-time.html#1-prepare-a-docker-container-image-for-remote-actions
+groupadd --gid 108 tipi-rbe && adduser --system --uid 108 --gid 108 -G gh-actions-group,wine,wheel --create-home --home-dir /home/tipi-rbe tipi-rbe \
+  && echo 'tipi-rbe ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/tipi-rbe
+
+
+# Get tipi to store in the right home for gh-action
+mkdir -p /usr/local/share/.tipi && chown tipi:tipi -R /usr/local/share/.tipi
+mkdir -p /home/tipi/.ssh && chown tipi:tipi -R /home/tipi/.ssh
+
+# http_proxy temp folder for IPC & logging for the additional users
+mkdir /run/user/1001 \
+ && chown tipi:tipi /run/user/1001 \
+ && chmod 0700 /run/user/1001
+
+mkdir /run/user/1000 \
+ && chown tipi-large:tipi-large /run/user/1000 \
+ && chmod 0700 /run/user/1000
+
+ RUN mkdir /run/user/108 \
+ && chown tipi-rbe:tipi-rbe /run/user/108 \
+ && chmod 0700 /run/user/108
+
+chsh -s /bin/bash root
+chsh -s /bin/bash tipi
+chsh -s /bin/bash tipi-large
+chsh -s /bin/bash tipi-rbe
+
+echo "export SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" >> /home/tipi/.bashrc
+echo "export SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" >>/home/tipi-large/.bashrc
+echo "export SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" >> /home/tipi-rbe/.bashrc
+echo "export SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" >> /root/.bashrc
+
+export TIPI_DISTRO_MODE=all
+su tipi -w TIPI_DISTRO_MODE -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_macos_linux.sh)"
+su tipi -w TIPI_DISTRO_MODE -c 'cd /home/tipi && mkdir main && echo "int main(){return 0;}" > ./main/main.cpp && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main'
+
+rm -rf ./main \
+  && rm -rf /usr/local/share/.tipi/downloads/* \
+  && rm -rf /usr/local/share/.tipi/v*.d/* \
+  && rm -rf /usr/local/share/.tipi/v*.w/*

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -55,6 +55,7 @@ chsh -s /bin/bash tipi-rbe
 
 
 export TIPI_DISTRO_MODE=all
+export USER=tipi
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_macos_linux.sh)"
 mkdir main && echo "int main(){return 0;}" >> ./main/main.cpp \
   && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main \

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -56,10 +56,8 @@ chsh -s /bin/bash tipi-rbe
 
 
 export TIPI_DISTRO_MODE=all
-export USER=tipi
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_macos_linux.sh)"
-
-su tipi -c 'cd /home/tipi && mkdir main && echo "int main(){return 0;}" > ./main/main.cpp && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main'
+su tipi -w TIPI_DISTRO_MODE -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_macos_linux.sh)"
+su tipi -w TIPI_DISTRO_MODE -c 'cd /home/tipi && mkdir main && echo "int main(){return 0;}" > ./main/main.cpp && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main'
 
 rm -rf ./main \
   && rm -rf /usr/local/share/.tipi/downloads/* \

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# tipi docker setup script
+# Copyright 2024 - tipi technologies Ltd (Zürich)
+
+apt-get -y update && apt-get install -y \
+  openssh-server \
+  sudo \
+  curl \
+  unzip \
+  build-essential \
+  git \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Enable login with tipi generated ssh-rsa on Ubuntu 22 and onwards
+printf "\nPubkeyAcceptedAlgorithms +ssh-rsa\n" > /etc/ssh/sshd_config.d/add-ssh-rsa.conf
+
+# User id 1001 is the user on Github Default Runner and 123 is the group of the files on the Github Default Runner
+addgroup --gid 123 gh-actions-group
+addgroup --gid 124 wine
+
+addgroup --gid 1001 tipi && useradd --system --uid 1001 --gid 1001 -G gh-actions-group,wine,sudo --create-home --home-dir /home/tipi tipi \
+  && echo 'tipi ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/tipi
+
+addgroup --gid 1000 tipi-large && useradd --system --uid 1000 --gid 1000 -G gh-actions-group,wine,sudo --create-home --home-dir /home/tipi-large tipi-large \
+  && echo 'tipi-large ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/tipi-large
+
+# https://docs.engflow.com/re/client/bazel-first-time.html#1-prepare-a-docker-container-image-for-remote-actions
+addgroup --gid 108 tipi-rbe && useradd --system --uid 108 --gid 108 -G gh-actions-group,wine,sudo --create-home --home-dir /home/tipi-rbe tipi-rbe \
+  && echo 'tipi-rbe ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/tipi-rbe
+
+
+# Get tipi to store in the right home for gh-action
+mkdir -p /usr/local/share/.tipi && chown tipi:tipi -R /usr/local/share/.tipi
+mkdir -p /home/tipi/.ssh && chown tipi:tipi -R /home/tipi/.ssh
+
+# http_proxy temp folder for IPC & logging for the additional users
+mkdir /run/user/1001 \
+ && chown tipi:tipi /run/user/1001 \
+ && chmod 0700 /run/user/1001
+
+mkdir /run/user/1000 \
+ && chown tipi-large:tipi-large /run/user/1000 \
+ && chmod 0700 /run/user/1000
+
+mkdir /run/user/108 \
+ && chown tipi-rbe:tipi-rbe /run/user/108 \
+ && chmod 0700 /run/user/108
+
+chsh -s /bin/bash root
+chsh -s /bin/bash tipi
+chsh -s /bin/bash tipi-large
+chsh -s /bin/bash tipi-rbe
+
+
+export TIPI_DISTRO_MODE=all
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_macos_linux.sh)"
+mkdir main && echo "int main(){return 0;}" >> ./main/main.cpp \
+  && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main \
+  && rm -rf ./main \
+  && rm -rf /usr/local/share/.tipi/downloads/* \
+  && rm -rf /usr/local/share/.tipi/v*.d/* \
+  && rm -rf /usr/local/share/.tipi/v*.w/*

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -59,7 +59,7 @@ export TIPI_DISTRO_MODE=all
 export USER=tipi
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_macos_linux.sh)"
 
-mkdir main && echo "int main(){return 0;}" >> ./main/main.cpp \
+su ${USER} && cd /home/${USER} && mkdir main && echo "int main(){return 0;}" >> ./main/main.cpp \
   && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main \
   && rm -rf ./main \
   && rm -rf /usr/local/share/.tipi/downloads/* \

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -59,9 +59,9 @@ export TIPI_DISTRO_MODE=all
 export USER=tipi
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_macos_linux.sh)"
 
-su ${USER} && cd /home/${USER} && mkdir main && echo "int main(){return 0;}" >> ./main/main.cpp \
-  && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main \
-  && rm -rf ./main \
+su tipi /bin/bash -c 'cd /home/tipi && mkdir main && echo "int main(){return 0;}" > ./main/main.cpp && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main'
+
+rm -rf ./main \
   && rm -rf /usr/local/share/.tipi/downloads/* \
   && rm -rf /usr/local/share/.tipi/v*.d/* \
   && rm -rf /usr/local/share/.tipi/v*.w/*

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -15,6 +15,7 @@ apt-get -y update && apt-get install -y \
 
 # Enable login with tipi generated ssh-rsa on Ubuntu 22 and onwards
 printf "\nPubkeyAcceptedAlgorithms +ssh-rsa\n" > /etc/ssh/sshd_config.d/add-ssh-rsa.conf
+service ssh start # Create /run/sshd privilege separation directory, the docker CMD should still be something like `/usr/sbin/sshd -D -o ListenAddress=0.0.0.0 -e;`
 
 # User id 1001 is the user on Github Default Runner and 123 is the group of the files on the Github Default Runner
 addgroup --gid 123 gh-actions-group
@@ -57,6 +58,7 @@ chsh -s /bin/bash tipi-rbe
 export TIPI_DISTRO_MODE=all
 export USER=tipi
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_macos_linux.sh)"
+
 mkdir main && echo "int main(){return 0;}" >> ./main/main.cpp \
   && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main \
   && rm -rf ./main \

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# tipi docker setup script
+# tipi docker setup script for debian and arch derivativees
 # Copyright 2024 - tipi technologies Ltd (Zürich)
 
 apt-get -y update && apt-get install -y \

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -59,7 +59,7 @@ export TIPI_DISTRO_MODE=all
 export USER=tipi
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_macos_linux.sh)"
 
-su tipi /bin/bash -c 'cd /home/tipi && mkdir main && echo "int main(){return 0;}" > ./main/main.cpp && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main'
+su tipi -c 'cd /home/tipi && mkdir main && echo "int main(){return 0;}" > ./main/main.cpp && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main'
 
 rm -rf ./main \
   && rm -rf /usr/local/share/.tipi/downloads/* \


### PR DESCRIPTION
This simplifies adding tipi support to any docker environment via centralized scripts, this is particularly useful when using the automatic Docker + CMake Toolchain file builder to be officially introduced in version 0.0.62.

## debian/ubuntu derivatives
```Dockerfile
RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/container/ubuntu.sh)"
EXPOSE 22
```

## centos derivatives
```Dockerfile
RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/container/centos.sh)"
EXPOSE 22
```

### WIP
- [x] test ubuntu creation
- [ ] test centos creation