### PR TITLE
:rocket: Release v0.0.63 defaults + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # tipi.build cli : CHANGELOG
 
+## v0.0.63 - Zappy Zebu ⚡️
+
+### Features
+- :new: `cmake-re` does **hermetic** containerized build by default ( TIPI_LOCAL_CONTAINER_RUNNER is enabled by default unless `--host` is provided )
+- ⚡️ Fast local hermetic build retrieval with bind mounts in `$HOME/.tipi/containers-workdirs`
+- `<toolchain-name>.layers.json` allow for Layered CMake RE Environments and Toolchain specifications for better toolchain composition and cache segregation
+
+### Bug Fixes
+- Fixed intermittent hanging of cmake-re command on `ctrl-c`  on macOS M2
+
+tipi-src: 95be4eaecf9f3dff414fe0bc9413ff7ecfc44a02
+tipi-commit: e3bb016e5b59b6588e234670161948c58625d33f
+
+### Archives Checksums
+tipi-v0.0.63-windows-win64.zip:AEFEC1E93F780E1A04056BD448FBF1B279E256D1
+tipi-v0.0.63-linux-x86_64.zip:4C995EB6452F785B63777A4C3FF0AAAA182120C2
+tipi-v0.0.63-macOS.zip:AAC49D4F63AF42C20D8577B5E6F25B1502CF62F8
+
 ## v0.0.62 - Yodelling Yeti 🐾
 
 ### Features

--- a/install/container/centos.sh
+++ b/install/container/centos.sh
@@ -64,7 +64,7 @@ echo "export SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" >>
 echo "export SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" >> /root/.bashrc
 
 export TIPI_DISTRO_MODE=all
-su tipi -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_macos_linux.sh)"
+su tipi -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.63/install/install_for_macos_linux.sh)"
 su tipi -c 'cd /home/tipi && mkdir main && echo "int main(){return 0;}" > ./main/main.cpp && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main'
 
 rm -rf ./main \

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -56,7 +56,7 @@ chsh -s /bin/bash tipi-rbe
 
 
 export TIPI_DISTRO_MODE=all
-su tipi -w TIPI_DISTRO_MODE -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_macos_linux.sh)"
+su tipi -w TIPI_DISTRO_MODE -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.63/install/install_for_macos_linux.sh)"
 su tipi -w TIPI_DISTRO_MODE -c 'cd /home/tipi && mkdir main && echo "int main(){return 0;}" > ./main/main.cpp && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main'
 
 rm -rf ./main \

--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -32,7 +32,7 @@ should_install_unzip() {
 # impl.
 ### 
 
-VERSION="${TIPI_INSTALL_VERSION:-v0.0.62}"
+VERSION="${TIPI_INSTALL_VERSION:-v0.0.63}"
 INSTALL_FOLDER=/usr/local
 
 if [[ -z "${TIPI_INSTALL_SOURCE}" ]]; then

--- a/install/install_for_windows.ps1
+++ b/install/install_for_windows.ps1
@@ -58,7 +58,7 @@ if([bool]::TryParse($env:TIPI_INSTALL_SYSTEM, [ref]$system_install)) {
 }
 
 if ([string]::IsNullOrEmpty($version_to_use)) {
-    $version_to_use="v0.0.62"
+    $version_to_use="v0.0.63"
 }
 
 if ([string]::IsNullOrEmpty($INSTALL_FOLDER)) {


### PR DESCRIPTION
# tipi.build cli : CHANGELOG

## v0.0.63 - Zappy Zebu ⚡️

### Features
- :new: `cmake-re` does **hermetic** containerized build by default ( TIPI_LOCAL_CONTAINER_RUNNER is enabled by default unless `--host` is provided )
- ⚡️ Fast local hermetic build retrieval with bind mounts in `$HOME/.tipi/containers-workdirs`
- `<toolchain-name>.layers.json` allow for Layered CMake RE Environments and Toolchain specifications for better toolchain composition and cache segregation

### Bug Fixes
- Fixed intermittent hanging of cmake-re command on `ctrl-c`  on macOS M2

tipi-src: 95be4eaecf9f3dff414fe0bc9413ff7ecfc44a02
tipi-commit: e3bb016e5b59b6588e234670161948c58625d33f

### Archives Checksums
tipi-v0.0.63-windows-win64.zip:AEFEC1E93F780E1A04056BD448FBF1B279E256D1
tipi-v0.0.63-linux-x86_64.zip:4C995EB6452F785B63777A4C3FF0AAAA182120C2
tipi-v0.0.63-macOS.zip:AAC49D4F63AF42C20D8577B5E6F25B1502CF62F8
