### PR TITLE
Release v0.0.64 - Ascending Apollo 🦋🚀 - defaults + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # tipi.build cli : CHANGELOG
 
+## v0.0.64 - Ascending Apollo 🦋🚀
+
+### Features
+- 🆕 Support for linux hermetic+containerized build on Windows 💻 hosts
+
+### Bug Fixes
+- Ensure hermetic+containerized build on macOS allows git cloning operation in build ( _e.g._ FetchContent ) by declaring them as `git safe.directory`  when VirtioFS is not able to synchronize user rights properly. 
+- Proper symlink creation in hermetic build when build dir path has a trailing slash
+- Changed the local_docker_service runner address to ipv4 notation to avoid ipv6 localhost resolution issues
+
+tipi-src: 4fc488aba1abe607ea191d22094c1b6d402f21b5
+tipi-commit: 4fc488aba1abe607ea191d22094c1b6d402f21b5
+
+### Archives Checksums
+tipi-v0.0.64-windows-win64.zip:16B5B7AF665C2EA03F3C4CB49DB8E9133D44DC3C
+tipi-v0.0.64-linux-x86_64.zip:8C0C641D78AE7EB08F14AF5C15564E5EA24BA55F
+tipi-v0.0.64-macOS.zip:E99FFE584BCCE5E1B590359EA9F445B72B188D6E
+
 ## v0.0.63 - Zappy Zebu ⚡️
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # tipi.build cli : CHANGELOG
 
+## v0.0.63 - Zappy Zebu ⚡️
+
+### Features
+- :new: `cmake-re` does **hermetic** containerized build by default ( TIPI_LOCAL_CONTAINER_RUNNER is enabled by default unless `--host` is provided )
+- ⚡️ Fast local hermetic build retrieval with bind mounts in `$HOME/.tipi/containers-workdirs`
+- `<toolchain-name>.layers.json` allow for Layered CMake RE Environments and Toolchain specifications for better toolchain composition and cache segregation
+
+### Bug Fixes
+- Fixed intermittent hanging of cmake-re command on `ctrl-c`  on macOS M2
+
+tipi-src: 95be4eaecf9f3dff414fe0bc9413ff7ecfc44a02
+tipi-commit: e3bb016e5b59b6588e234670161948c58625d33f
+
+### Archives Checksums
+tipi-v0.0.63-windows-win64.zip:AEFEC1E93F780E1A04056BD448FBF1B279E256D1
+tipi-v0.0.63-linux-x86_64.zip:4C995EB6452F785B63777A4C3FF0AAAA182120C2
+tipi-v0.0.63-macOS.zip:AAC49D4F63AF42C20D8577B5E6F25B1502CF62F8
+
 ## v0.0.62 - Yodelling Yeti 🐾
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Please head up to [our website](https://tipi.build)
 
 ## Features
+- :new: `cmake-re` local **hermetic** and containerized build by default
 - Provides a fully working C++ build environment on any platform
 - tipi speeds up your workflow with autoprovisioned cloud environments : toolchain, compilers, tools.
 - tipi is a dependency manager for C++ which fetches and compile any C++ project.

--- a/install/container/centos.sh
+++ b/install/container/centos.sh
@@ -67,7 +67,7 @@ echo "export SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" >>
 git config --system --add safe.directory "*"
 
 export TIPI_DISTRO_MODE=all
-su tipi -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.63/install/install_for_macos_linux.sh)"
+su tipi -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.64/install/install_for_macos_linux.sh)"
 su tipi -c 'cd /home/tipi && mkdir main && echo "int main(){return 0;}" > ./main/main.cpp && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main'
 
 rm -rf ./main \

--- a/install/container/centos.sh
+++ b/install/container/centos.sh
@@ -64,7 +64,7 @@ echo "export SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" >>
 echo "export SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" >> /root/.bashrc
 
 export TIPI_DISTRO_MODE=all
-su tipi -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_macos_linux.sh)"
+su tipi -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.63/install/install_for_macos_linux.sh)"
 su tipi -c 'cd /home/tipi && mkdir main && echo "int main(){return 0;}" > ./main/main.cpp && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main'
 
 rm -rf ./main \

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -56,7 +56,7 @@ chsh -s /bin/bash tipi-rbe
 
 
 export TIPI_DISTRO_MODE=all
-su tipi -w TIPI_DISTRO_MODE -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_macos_linux.sh)"
+su tipi -w TIPI_DISTRO_MODE -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.63/install/install_for_macos_linux.sh)"
 su tipi -w TIPI_DISTRO_MODE -c 'cd /home/tipi && mkdir main && echo "int main(){return 0;}" > ./main/main.cpp && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main'
 
 rm -rf ./main \

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -58,7 +58,7 @@ chsh -s /bin/bash tipi-rbe
 git config --system --add safe.directory "*"
 
 export TIPI_DISTRO_MODE=all
-su tipi -w TIPI_DISTRO_MODE -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.63/install/install_for_macos_linux.sh)"
+su tipi -w TIPI_DISTRO_MODE -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.64/install/install_for_macos_linux.sh)"
 su tipi -w TIPI_DISTRO_MODE -c 'cd /home/tipi && mkdir main && echo "int main(){return 0;}" > ./main/main.cpp && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main'
 
 rm -rf ./main \

--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -32,7 +32,7 @@ should_install_unzip() {
 # impl.
 ### 
 
-VERSION="${TIPI_INSTALL_VERSION:-v0.0.62}"
+VERSION="${TIPI_INSTALL_VERSION:-v0.0.63}"
 INSTALL_FOLDER=/usr/local
 
 if [[ -z "${TIPI_INSTALL_SOURCE}" ]]; then

--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -32,7 +32,7 @@ should_install_unzip() {
 # impl.
 ### 
 
-VERSION="${TIPI_INSTALL_VERSION:-v0.0.63}"
+VERSION="${TIPI_INSTALL_VERSION:-v0.0.64}"
 INSTALL_FOLDER=/usr/local
 
 if [[ -z "${TIPI_INSTALL_SOURCE}" ]]; then

--- a/install/install_for_windows.ps1
+++ b/install/install_for_windows.ps1
@@ -58,7 +58,7 @@ if([bool]::TryParse($env:TIPI_INSTALL_SYSTEM, [ref]$system_install)) {
 }
 
 if ([string]::IsNullOrEmpty($version_to_use)) {
-    $version_to_use="v0.0.62"
+    $version_to_use="v0.0.63"
 }
 
 if ([string]::IsNullOrEmpty($INSTALL_FOLDER)) {

--- a/install/install_for_windows.ps1
+++ b/install/install_for_windows.ps1
@@ -58,7 +58,7 @@ if([bool]::TryParse($env:TIPI_INSTALL_SYSTEM, [ref]$system_install)) {
 }
 
 if ([string]::IsNullOrEmpty($version_to_use)) {
-    $version_to_use="v0.0.63"
+    $version_to_use="v0.0.64"
 }
 
 if ([string]::IsNullOrEmpty($INSTALL_FOLDER)) {


### PR DESCRIPTION
# tipi.build cli : CHANGELOG

## v0.0.64 - Ascending Apollo 🦋🚀

### Features
- 🆕 Support for linux hermetic+containerized build on Windows 💻 hosts

### Bug Fixes
- Ensure hermetic+containerized build on macOS allows git cloning operation in build ( _e.g._ FetchContent ) by declaring them as `git safe.directory`  when VirtioFS is not able to synchronize user rights properly. 
- Proper symlink creation in hermetic build when build dir path has a trailing slash
- Changed the local_docker_service runner address to ipv4 notation to avoid ipv6 localhost resolution issues

tipi-src: 4fc488aba1abe607ea191d22094c1b6d402f21b5
tipi-commit: 4fc488aba1abe607ea191d22094c1b6d402f21b5

### Archives Checksums
tipi-v0.0.64-windows-win64.zip:16B5B7AF665C2EA03F3C4CB49DB8E9133D44DC3C
tipi-v0.0.64-linux-x86_64.zip:8C0C641D78AE7EB08F14AF5C15564E5EA24BA55F
tipi-v0.0.64-macOS.zip:E99FFE584BCCE5E1B590359EA9F445B72B188D6E
