### PR TITLE
Releasev0.0.65 - Brisk Bobcat 🐱 - defaults + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 ### Bug Fixes
 - Enhanced the parser to improve case detection, ensuring more accurate recognition of user input.
 
-tipi-src: XXXPLACEHOLDERXXX
+tipi-src: fc75fdc175cdaaff40f49011cb97b53d954baaac
 tipi-commit: ab6076f2a9dd8982f87ae848238ed84e7fe86037
 
 ### Archives Checksums
-tipi-v0.0.65-windows-win64.zip:XXXPLACEHOLDERXXX
-tipi-v0.0.65-linux-x86_64.zip:XXXPLACEHOLDERXXX
-tipi-v0.0.65-macOS.zip:XXXPLACEHOLDERXXX
+tipi-v0.0.65-windows-win64.zip:8B26B528488154E432B4DF76D6F7B9AD854ACE47
+tipi-v0.0.65-linux-x86_64.zip:4DD487A7DE98627D5FB991671710E9A5C26162C9
+tipi-v0.0.65-macOS.zip:16353ED60D4D071BEC25B65E65F4D1A277E97CCF
 
 ## v0.0.64 - Ascending Apollo 🦋🚀
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # tipi.build cli : CHANGELOG
 
+## v0.0.65 - Brisk Bobcat 🐱
+
+### Bug Fixes
+- Enhanced the parser to improve case detection, ensuring more accurate recognition of user input.
+
+tipi-src: XXXPLACEHOLDERXXX
+tipi-commit: ab6076f2a9dd8982f87ae848238ed84e7fe86037
+
+### Archives Checksums
+tipi-v0.0.65-windows-win64.zip:XXXPLACEHOLDERXXX
+tipi-v0.0.65-linux-x86_64.zip:XXXPLACEHOLDERXXX
+tipi-v0.0.65-macOS.zip:XXXPLACEHOLDERXXX
+
 ## v0.0.64 - Ascending Apollo 🦋🚀
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 ### Bug Fixes
 - Enhanced the parser to improve case detection, ensuring more accurate recognition of user input.
 
-tipi-src: fc75fdc175cdaaff40f49011cb97b53d954baaac
-tipi-commit: ab6076f2a9dd8982f87ae848238ed84e7fe86037
+tipi-src: 1a15bb38577ad3c843429aae12e197eb6c780185
+tipi-commit: eb9465966dba0c4d571a803e1bbbf002744b50ff
 
 ### Archives Checksums
-tipi-v0.0.65-windows-win64.zip:8B26B528488154E432B4DF76D6F7B9AD854ACE47
-tipi-v0.0.65-linux-x86_64.zip:4DD487A7DE98627D5FB991671710E9A5C26162C9
-tipi-v0.0.65-macOS.zip:16353ED60D4D071BEC25B65E65F4D1A277E97CCF
+tipi-v0.0.65-windows-win64.zip:3CFA834E79FEC8E74D841C4EF796EEA7015E5855
+tipi-v0.0.65-linux-x86_64.zip:1F5932DD8BB2564F25FC88D159CDD79433D24B82
+tipi-v0.0.65-macOS.zip:721221734F2D595A950A8F196D9E4311D30AAEFD
 
 ## v0.0.64 - Ascending Apollo 🦋🚀
 

--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -32,7 +32,7 @@ should_install_unzip() {
 # impl.
 ### 
 
-VERSION="${TIPI_INSTALL_VERSION:-v0.0.64}"
+VERSION="${TIPI_INSTALL_VERSION:-v0.0.65}"
 INSTALL_FOLDER=/usr/local
 
 if [[ -z "${TIPI_INSTALL_SOURCE}" ]]; then

--- a/install/install_for_windows.ps1
+++ b/install/install_for_windows.ps1
@@ -58,7 +58,7 @@ if([bool]::TryParse($env:TIPI_INSTALL_SYSTEM, [ref]$system_install)) {
 }
 
 if ([string]::IsNullOrEmpty($version_to_use)) {
-    $version_to_use="v0.0.64"
+    $version_to_use="v0.0.65"
 }
 
 if ([string]::IsNullOrEmpty($INSTALL_FOLDER)) {


### PR DESCRIPTION
# tipi.build cli : CHANGELOG

## v0.0.65 - Brisk Bobcat 🐱

### Bug Fixes
- Enhanced the parser to improve case detection, ensuring more accurate recognition of user input.

tipi-src: 1a15bb38577ad3c843429aae12e197eb6c780185
tipi-commit: eb9465966dba0c4d571a803e1bbbf002744b50ff

### Archives Checksums
tipi-v0.0.65-windows-win64.zip:3CFA834E79FEC8E74D841C4EF796EEA7015E5855
tipi-v0.0.65-linux-x86_64.zip:1F5932DD8BB2564F25FC88D159CDD79433D24B82
tipi-v0.0.65-macOS.zip:721221734F2D595A950A8F196D9E4311D30AAEFD