### PR TITLE
Release v0.0.67 - Dashing Duck 🦆

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # tipi.build cli : CHANGELOG
 
+## v0.0.67 - Dashing Duck 🦆
+
+### Bug Fixes
+- Allow building for Windows on ARM with Visual Studio.
+- Avoid unconditional appending of --test in cmake-re requests to the tipi backend.
+- Removed dependency on libnsl.so on Linux to improve compatibility and reduce unnecessary linkage.
+- For a containerized build, fix docker launch errors.
+
+tipi-src: a00f961be14aea98b8fbbc6bd898eab7b36d64bc
+tipi-commit: a00f961be14aea98b8fbbc6bd898eab7b36d64bc
+
+### Archives Checksums
+tipi-v0.0.67-windows-win64.zip:7749924980516E46EB1092DA0A7E320AD8FC165F
+tipi-v0.0.67-linux-x86_64.zip:761D77B6C9DDCA3B826BDD8EAF6DBFF73BEC556B
+tipi-v0.0.67-macOS.zip:EFCD65C1ABF08FBFE6F7D9F100B5247FE723364B
+
 ## v0.0.66 - Creative Cougar 🐾
 
 ### Bug Fixes

--- a/install/container/centos.sh
+++ b/install/container/centos.sh
@@ -67,7 +67,7 @@ echo "export SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" >>
 git config --system --add safe.directory "*"
 
 export TIPI_DISTRO_MODE=all
-su tipi -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.66/install/install_for_macos_linux.sh)"
+su tipi -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.67/install/install_for_macos_linux.sh)"
 su tipi -c 'cd /home/tipi && mkdir main && echo "int main(){return 0;}" > ./main/main.cpp && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main'
 
 rm -rf ./main \

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -58,7 +58,7 @@ chsh -s /bin/bash tipi-rbe
 git config --system --add safe.directory "*"
 
 export TIPI_DISTRO_MODE=all
-su tipi -w TIPI_DISTRO_MODE -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.66/install/install_for_macos_linux.sh)"
+su tipi -w TIPI_DISTRO_MODE -c "$(curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.67/install/install_for_macos_linux.sh)"
 su tipi -w TIPI_DISTRO_MODE -c 'cd /home/tipi && mkdir main && echo "int main(){return 0;}" > ./main/main.cpp && /usr/local/bin/tipi --dont-upgrade -v -t linux ./main'
 
 rm -rf ./main \

--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -32,7 +32,7 @@ should_install_unzip() {
 # impl.
 ### 
 
-VERSION="${TIPI_INSTALL_VERSION:-v0.0.66}"
+VERSION="${TIPI_INSTALL_VERSION:-v0.0.67}"
 INSTALL_FOLDER=/usr/local
 
 if [[ -z "${TIPI_INSTALL_SOURCE}" ]]; then

--- a/install/install_for_windows.ps1
+++ b/install/install_for_windows.ps1
@@ -58,7 +58,7 @@ if([bool]::TryParse($env:TIPI_INSTALL_SYSTEM, [ref]$system_install)) {
 }
 
 if ([string]::IsNullOrEmpty($version_to_use)) {
-    $version_to_use="v0.0.66"
+    $version_to_use="v0.0.67"
 }
 
 if ([string]::IsNullOrEmpty($INSTALL_FOLDER)) {


### PR DESCRIPTION
## v0.0.67 - Dashing Duck 🦆

### Bug Fixes
- Allow building for Windows on ARM with Visual Studio.
- Avoid unconditional appending of --test in cmake-re requests to the tipi backend.
- Removed dependency on libnsl.so on Linux to improve compatibility and reduce unnecessary linkage.
- For a containerized build, fix docker launch errors.

tipi-src: a00f961be14aea98b8fbbc6bd898eab7b36d64bc
tipi-commit: a00f961be14aea98b8fbbc6bd898eab7b36d64bc

### Archives Checksums
tipi-v0.0.67-windows-win64.zip:7749924980516E46EB1092DA0A7E320AD8FC165F
tipi-v0.0.67-linux-x86_64.zip:761D77B6C9DDCA3B826BDD8EAF6DBFF73BEC556B
tipi-v0.0.67-macOS.zip:EFCD65C1ABF08FBFE6F7D9F100B5247FE723364B