### PR TITLE
Restrict ownership and permission changes to tipi and cmake-re binaries

### DIFF
--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -90,7 +90,7 @@ if [ $? -eq 0 ]; then
     tipi_full_path=$INSTALL_FOLDER/bin/tipi
     cmake_full_path=$INSTALL_FOLDER/bin/cmake-re
 
-    for file in $INSTALL_FOLDER/bin/*; do
+    for file in "$tipi_full_path" "$cmake_full_path"; do
       if [ -f "$file" ]; then
         $PRIV_ELEV_CMD chown "${USER:=$(id -run)}" "$file"
         $PRIV_ELEV_CMD chmod a+x,u+w "$file"


### PR DESCRIPTION
This PR updates the post-install script to change ownership and permissions for only the two relevant binaries:
- tipi
- cmake-re

Previously, the script applied these changes to all files in the $INSTALL_FOLDER/bin/ directory, which could unintentionally affect unrelated files. This change improves precision and avoids modifying unexpected executables.