### PR TITLE
Support environment variable TIPI_INSTALL_LEGACY_PACKAGES in centos

### DIFF
--- a/install/container/centos.sh
+++ b/install/container/centos.sh
@@ -7,7 +7,6 @@ set -e
 yum update -y && yum makecache \
   && yum install -y openssh-server \
   sudo \
-  curl \
   unzip \
   git
 

--- a/install/container/centos.sh
+++ b/install/container/centos.sh
@@ -4,11 +4,31 @@
 
 set -e
 
-# INCLUDE+ common/Dockerfile.yum-install-required
 yum update -y && yum makecache \
- && yum install -y systemd procps-ng sudo shadow-utils passwd git libnsl sudo ca-certificates openssh-server openssh-clients util-linux-ng util-linux-user libuser python3 cmake3 \
- && yum groupinstall -y 'Development Tools' \
- && yum install -y perl-core perl-IPC-Cmd # OpenSSL 3 build system requires this
+  && yum install -y openssh-server \
+  sudo \
+  curl \
+  unzip \
+  git
+
+if [ "$TIPI_INSTALL_LEGACY_PACKAGES" = "ON" ]; then
+ # INCLUDE+ common/Dockerfile.yum-install-required
+  yum update -y && yum makecache \
+    && yum install -y systemd \
+    procps-ng \
+    shadow-utils \
+    passwd \
+    libnsl \
+    ca-certificates \
+    openssh-clients \
+    util-linux-ng \
+    util-linux-user \
+    libuser \
+    python3 \
+    cmake3 \
+    && yum groupinstall -y 'Development Tools' \
+    && yum install -y perl-core perl-IPC-Cmd # OpenSSL 3 build system requires this
+fi
 
 deprecated_X3_Root_CA=`trust dump --filter "pkcs11:id=%c4%a7%b1%a4%7b%2c%71%fa%db%e1%4b%90%75%ff%c4%15%60%85%89%10"`
 if [ ! -z "${deprecated_X3_Root_CA}" ]; then

--- a/install/container/centos.sh
+++ b/install/container/centos.sh
@@ -8,22 +8,26 @@ yum update -y && yum makecache \
   && yum install -y openssh-server \
   sudo \
   unzip \
-  git
+  git \
+  util-linux-ng \
+  util-linux-user \
+  libuser \
+  procps-ng \
+  shadow-utils \
+  passwd \
+  python3 \
+  which \
+  xz \
+  bzip2
+
+ # python3 which xz bzip2 are required for tipi build system (emsdk)
+
 
 if [ "$TIPI_INSTALL_LEGACY_PACKAGES" = "ON" ]; then
  # INCLUDE+ common/Dockerfile.yum-install-required
-  yum update -y && yum makecache \
-    && yum install -y systemd \
-    procps-ng \
-    shadow-utils \
-    passwd \
-    libnsl \
+  yum install -y systemd \
     ca-certificates \
     openssh-clients \
-    util-linux-ng \
-    util-linux-user \
-    libuser \
-    python3 \
     cmake3 \
     && yum groupinstall -y 'Development Tools' \
     && yum install -y perl-core perl-IPC-Cmd # OpenSSL 3 build system requires this

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -15,7 +15,7 @@ apt-get -y update && apt-get install -y \
 source /etc/lsb-release
 DISTRIB_RELEASE_MAJOR=`echo $DISTRIB_RELEASE | sed 's/\([0-9]\+\)\..*/\1/'`
 
-if [ -n "$TIPI_INSTALL_LEGACY_PACKAGES" ]; then
+if [ "$TIPI_INSTALL_LEGACY_PACKAGES" = "ON" ]; then
   #INCLUDE+ common/Dockerfile.apt-install-required
   apt-get -y update && apt-get install -y \
     locales \


### PR DESCRIPTION
the purpose of this environment and mode variable is to let the user choose whether or not to use all the tools installed by default in docker in the past.