### PR TITLE
🆕 add ci job to test docker build in centos

### DIFF
--- a/.github/workflows/check_container_build.yaml
+++ b/.github/workflows/check_container_build.yaml
@@ -53,3 +53,44 @@ jobs:
           cat install/container/environments/linux-ubuntu-2404.pkr.js/linux-ubuntu-2404.Dockerfile
 
           bin/cmake-re -S install/container/ -DCMAKE_TOOLCHAIN_FILE=install/container/environments/linux-ubuntu-2404.cmake -B build -vv
+
+
+  docker-build-centos:
+    name: docker-build-centos
+    runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_USER: tipibuild 
+      TIPI_DISTRO_MODE: default
+      TIPI_DISTRO_JSON_URL: https://raw.githubusercontent.com/tipi-build/distro/442a423e65f09ab0290609bc15f382585e89103e/distro.json
+      TIPI_DISTRO_JSON_SHA1: 39ace975db0eb1f5a02318130fb425d21731ea5c
+      version_in_development: v0.0.72
+      TIPI_ACCESS_TOKEN: ${{ secrets.CLI_TIPI_TEST_USER_TIPI_ACCESS_TOKEN }}
+      TIPI_REFRESH_TOKEN: ${{ secrets.CLI_TIPI_TEST_USER_TIPI_REFRESH_TOKEN }}
+      TIPI_VAULT_PASSPHRASE: ${{ secrets.CLI_TIPI_TEST_USER_TIPI_VAULT_PASSPHRASE }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+          submodules: true
+
+      - name: cmake-re build docker image
+        run: |
+          sudo mkdir -p /usr/local/share/.tipi
+          sudo chown -R ${USER:=$(/usr/bin/id -run)} /usr/local/share/.tipi
+          sudo chmod -R 777 /usr/local/share/.tipi
+          curl -fSSL https://github.com/tipi-build/cli/releases/download/${{ env.version_in_development }}/tipi-${{ env.version_in_development }}-linux-x86_64.zip \
+            -o install/container/environments/linux-almalinux-95.pkr.js/tipi-linux-x86_64.zip
+          cp install/container/centos.sh install/container/environments/linux-almalinux-95.pkr.js/centos.sh
+          unzip -n install/container/environments/linux-almalinux-95.pkr.js/tipi-linux-x86_64.zip
+          bin/tipi connect -v --dont-upgrade
+
+          # Patch for unsupported feature in v0.0.72
+          pushd install/container/environments
+            git apply ../0002-gear-temporarily-FORCE-new-distro-on-old-version-sup-on-centos.patch
+          popd
+
+          # Forward integrate current centos.sh
+          sed -i 's#RUN curl -fsSL https://.*/centos.sh -o centos.sh#COPY centos.sh /centos.sh \nRUN curl -fsSL file:///centos.sh -o centos.sh#g' install/container/environments/linux-almalinux-95.pkr.js/linux-almalinux-95.Dockerfile
+          cat install/container/environments/linux-almalinux-95.pkr.js/linux-almalinux-95.Dockerfile
+
+          bin/cmake-re -S install/container/ -DCMAKE_TOOLCHAIN_FILE=install/container/environments/linux-almalinux-95.cmake -B build -vv

--- a/install/container/0002-gear-temporarily-FORCE-new-distro-on-old-version-sup-on-centos.patch
+++ b/install/container/0002-gear-temporarily-FORCE-new-distro-on-old-version-sup-on-centos.patch
@@ -1,0 +1,29 @@
+diff --git a/linux-almalinux-95.pkr.js/linux-almalinux-95.Dockerfile b/linux-almalinux-95.pkr.js/linux-almalinux-95.Dockerfile
+index 3c44c79..3b1ad1b 100644
+--- a/linux-almalinux-95.pkr.js/linux-almalinux-95.Dockerfile
++++ b/linux-almalinux-95.pkr.js/linux-almalinux-95.Dockerfile
+@@ -3,6 +3,11 @@ FROM ${ALMALINUX_9_5}
+ 
+ # Install tipi and cmake-re
+ ENV TIPI_DISTRO_MODE=all
++ENV TIPI_DISTRO_JSON=https://raw.githubusercontent.com/tipi-build/distro/442a423e65f09ab0290609bc15f382585e89103e/distro.json
++ENV TIPI_DISTRO_JSON_SHA1=39ace975db0eb1f5a02318130fb425d21731ea5c
++RUN echo "TIPI_DISTRO_MODE=${TIPI_DISTRO_MODE}" >> /etc/environment
++RUN echo "TIPI_DISTRO_JSON=${TIPI_DISTRO_JSON}" >> /etc/environment
++RUN echo "TIPI_DISTRO_JSON_SHA1=${TIPI_DISTRO_JSON_SHA1}" >> /etc/environment
+ ENV TIPI_INSTALL_LEGACY_PACKAGES=ON
+ ENV SUDO_GROUP=wheel
+ ENV TIPI_INSTALL_SOURCE=file:///tipi-linux-x86_64.zip
+diff --git a/linux-almalinux-95.pkr.js/linux-almalinux-95.pkr.js b/linux-almalinux-95.pkr.js/linux-almalinux-95.pkr.js
+index 6ec216e..14ec3f1 100644
+--- a/linux-almalinux-95.pkr.js/linux-almalinux-95.pkr.js
++++ b/linux-almalinux-95.pkr.js/linux-almalinux-95.pkr.js
+@@ -3,7 +3,7 @@
+   "builders": [
+     {
+       "type": "docker",
+-      "image": "tipibuild/tipi-almalinux-95:{{tipi_cli_local_version}}",
++      "image": "tipibuild/tipi-almalinux-95:{{tipi_cli_version}}",
+       "commit": true
+     }
+   ],


### PR DESCRIPTION
the purpose of the pr is to add a job ci that allows testing of centos containers