### PR TITLE
🚀 release v0.0.75

### DIFF
--- a/.github/workflows/check_container_build.yaml
+++ b/.github/workflows/check_container_build.yaml
@@ -18,7 +18,7 @@ env:
   TIPI_DISTRO_MODE: default
   TIPI_DISTRO_JSON_URL: https://raw.githubusercontent.com/tipi-build/distro/442a423e65f09ab0290609bc15f382585e89103e/distro.json
   TIPI_DISTRO_JSON_SHA1: 39ace975db0eb1f5a02318130fb425d21731ea5c
-  version_in_development: v0.0.74
+  version_in_development: v0.0.75
   TIPI_ACCESS_TOKEN: ${{ secrets.CLI_TIPI_TEST_USER_TIPI_ACCESS_TOKEN }}
   TIPI_REFRESH_TOKEN: ${{ secrets.CLI_TIPI_TEST_USER_TIPI_REFRESH_TOKEN }}
   TIPI_VAULT_PASSPHRASE: ${{ secrets.CLI_TIPI_TEST_USER_TIPI_VAULT_PASSPHRASE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # tipi.build cli : CHANGELOG
 
+
+## v0.0.75 - Idem​po​tent Icadyptes ❄️🐾
+### Features
+- ISO 646 support: alternative C++ operators and tokens in `--distributed` builds
+- C95 alternative tokens support
+
+### Bug Fix
+- Builds now respect the TIPI_DISTRO_MODE specified in the Dockerfile environment for container builds and remote builds on Linux.
+
+tipi-src:b636058ff74828f4ab49507abc50efa9f9eed85d
+
+### Archives Checksums
+tipi-v0.0.75-windows-win64.zip:028BC37C71A40E4DF85BBE2E6631178F967B41F7
+tipi-v0.0.75-linux-x86_64.zip:F85143D4E9016618E493B501D219913AAB4CFFA3
+tipi-v0.0.75-macOS.zip:807FDEC325F6E98092B7ED00B3A8A7A15A281BFC
+
+
 ## v0.0.74 - Hybrid Hedgehog 🦔
 ### Features
 - `cmake-re [--host] [--distributed]` runs independently of a tipi.build account (no `tipi connect` required)

--- a/install/container/centos.sh
+++ b/install/container/centos.sh
@@ -113,7 +113,7 @@ git config --system --add safe.directory "*"
 
 export TIPI_DISTRO_MODE=${TIPI_DISTRO_MODE:-default}
 export TIPI_ENV_WHITELIST=${TIPI_ENV_WHITELIST:-TIPI_INSTALL_SOURCE,TIPI_DISTRO_MODE,TIPI_DISTRO_JSON,TIPI_DISTRO_JSON_SHA1}
-su tipi -c "cd ~ && curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.74/install/install_for_macos_linux.sh -o install_for_macos_linux.sh && /bin/bash install_for_macos_linux.sh"
+su tipi -c "cd ~ && curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.75/install/install_for_macos_linux.sh -o install_for_macos_linux.sh && /bin/bash install_for_macos_linux.sh"
 
 rm -rf ./main \
   && rm -rf /usr/local/share/.tipi/downloads/* \

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -157,7 +157,7 @@ if [ "$TIPI_INSTALL_LEGACY_PACKAGES" = "ON" ]; then
 fi
 
 # INCLUDE+ common/Dockerfile.install-tipi
-su tipi -c 'cd ~ && curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.74/install/install_for_macos_linux.sh -o install_for_macos_linux.sh && /bin/bash install_for_macos_linux.sh'
+su tipi -c 'cd ~ && curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.75/install/install_for_macos_linux.sh -o install_for_macos_linux.sh && /bin/bash install_for_macos_linux.sh'
 
 rm -rf ./main \
   && rm -rf /usr/local/share/.tipi/downloads/* \

--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -41,7 +41,7 @@ request_install_permission() {
 # impl.
 ### 
 
-VERSION="${TIPI_INSTALL_VERSION:-v0.0.74}"
+VERSION="${TIPI_INSTALL_VERSION:-v0.0.75}"
 INSTALL_FOLDER=/usr/local
 
 if [[ -z "${TIPI_INSTALL_SOURCE}" ]]; then

--- a/install/install_for_windows.ps1
+++ b/install/install_for_windows.ps1
@@ -58,7 +58,7 @@ if([bool]::TryParse($env:TIPI_INSTALL_SYSTEM, [ref]$system_install)) {
 }
 
 if ([string]::IsNullOrEmpty($version_to_use)) {
-    $version_to_use="v0.0.74"
+    $version_to_use="v0.0.75"
 }
 
 if ([string]::IsNullOrEmpty($INSTALL_FOLDER)) {


### PR DESCRIPTION
The purpose of this PR is to prepare the release of v0.0.75 of tipi/cmake-re.