### PR TITLE
🚀 Release v0.0.76

### DIFF
--- a/.github/workflows/check_container_build.yaml
+++ b/.github/workflows/check_container_build.yaml
@@ -18,7 +18,7 @@ env:
   TIPI_DISTRO_MODE: default
   TIPI_DISTRO_JSON_URL: https://raw.githubusercontent.com/tipi-build/distro/442a423e65f09ab0290609bc15f382585e89103e/distro.json
   TIPI_DISTRO_JSON_SHA1: 39ace975db0eb1f5a02318130fb425d21731ea5c
-  version_in_development: v0.0.75
+  version_in_development: v0.0.76
   TIPI_ACCESS_TOKEN: ${{ secrets.CLI_TIPI_TEST_USER_TIPI_ACCESS_TOKEN }}
   TIPI_REFRESH_TOKEN: ${{ secrets.CLI_TIPI_TEST_USER_TIPI_REFRESH_TOKEN }}
   TIPI_VAULT_PASSPHRASE: ${{ secrets.CLI_TIPI_TEST_USER_TIPI_VAULT_PASSPHRASE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # tipi.build cli : CHANGELOG
 
+## v0.0.76 - Jovial Jaguar 🐆
+### Features
+- Added tipi-linker-driver to support remote linking with the cluster in distributed mode.
+- Improves observability and enables finer analysis of distributed builds.(Actions now include `ActionMnemonic`)
+
+### Bug Fix
+- Avoided cache poisoning caused by absolute paths to the `ar/ranlib driver` in `tipi_cmake_override_ar_ranlib.cmake`.
+- Moved `tipi_cmake_override_ar_ranlib.cmake` to the build folder to avoid cache poisoning
+
+tipi-src:c8ef0342431279b2a5923aa5e0b0f92ebf7754c4
+
+### Archives Checksums
+tipi-v0.0.76-windows-win64.zip:XXXX
+tipi-v0.0.76-linux-x86_64.zip:XXXX
+tipi-v0.0.76-macOS.zip:XXX
+
 
 ## v0.0.75 - Idem​po​tent Icadyptes ❄️🐾
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@
 tipi-src:c8ef0342431279b2a5923aa5e0b0f92ebf7754c4
 
 ### Archives Checksums
-tipi-v0.0.76-windows-win64.zip:XXXX
-tipi-v0.0.76-linux-x86_64.zip:XXXX
-tipi-v0.0.76-macOS.zip:XXX
+tipi-v0.0.76-windows-win64.zip:A5E6D60D6E0B7D079CBB990B2F07E4C24FA09CA2
+tipi-v0.0.76-linux-x86_64.zip:07AC052A19C10B9E1A21A5B367883F446B60C560
+tipi-v0.0.76-macOS.zip:D2FAEAD0142C08CC8EFECB8851C8151D19FABD8F
 
 
 ## v0.0.75 - Idem​po​tent Icadyptes ❄️🐾

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,11 @@
 
 ## v0.0.76 - Jovial Jaguar 🐆
 ### Features
-- Added tipi-linker-driver to support remote linking with the cluster in distributed mode.
-- Improves observability and enables finer analysis of distributed builds.(Actions now include `ActionMnemonic`)
+- 🆕 `--distributed` linking for executable and shared object enabled by default
+- 📈 RBE Actions report mnemonics (`CcCompile`,`Link`,`Archive`...) improving distribution scheduling and downloadable profiling data of `--distributed` builds
 
 ### Bug Fix
-- Avoided cache poisoning caused by absolute paths to the `ar/ranlib driver` in `tipi_cmake_override_ar_ranlib.cmake`.
-- Moved `tipi_cmake_override_ar_ranlib.cmake` to the build folder to avoid cache poisoning
+- Fixed build-cache entry dependency to cmake-re version caused by absolute paths to the `tipi-ar|ranlib-driver`
 
 tipi-src:c8ef0342431279b2a5923aa5e0b0f92ebf7754c4
 

--- a/install/container/centos.sh
+++ b/install/container/centos.sh
@@ -113,7 +113,7 @@ git config --system --add safe.directory "*"
 
 export TIPI_DISTRO_MODE=${TIPI_DISTRO_MODE:-default}
 export TIPI_ENV_WHITELIST=${TIPI_ENV_WHITELIST:-TIPI_INSTALL_SOURCE,TIPI_DISTRO_MODE,TIPI_DISTRO_JSON,TIPI_DISTRO_JSON_SHA1}
-su tipi -c "cd ~ && curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.75/install/install_for_macos_linux.sh -o install_for_macos_linux.sh && /bin/bash install_for_macos_linux.sh"
+su tipi -c "cd ~ && curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.76/install/install_for_macos_linux.sh -o install_for_macos_linux.sh && /bin/bash install_for_macos_linux.sh"
 
 rm -rf ./main \
   && rm -rf /usr/local/share/.tipi/downloads/* \

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -157,7 +157,7 @@ if [ "$TIPI_INSTALL_LEGACY_PACKAGES" = "ON" ]; then
 fi
 
 # INCLUDE+ common/Dockerfile.install-tipi
-su tipi -c 'cd ~ && curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.75/install/install_for_macos_linux.sh -o install_for_macos_linux.sh && /bin/bash install_for_macos_linux.sh'
+su tipi -c 'cd ~ && curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/feature/release-v0.0.76/install/install_for_macos_linux.sh -o install_for_macos_linux.sh && /bin/bash install_for_macos_linux.sh'
 
 rm -rf ./main \
   && rm -rf /usr/local/share/.tipi/downloads/* \

--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -41,7 +41,7 @@ request_install_permission() {
 # impl.
 ### 
 
-VERSION="${TIPI_INSTALL_VERSION:-v0.0.75}"
+VERSION="${TIPI_INSTALL_VERSION:-v0.0.76}"
 INSTALL_FOLDER=/usr/local
 
 if [[ -z "${TIPI_INSTALL_SOURCE}" ]]; then

--- a/install/install_for_windows.ps1
+++ b/install/install_for_windows.ps1
@@ -58,7 +58,7 @@ if([bool]::TryParse($env:TIPI_INSTALL_SYSTEM, [ref]$system_install)) {
 }
 
 if ([string]::IsNullOrEmpty($version_to_use)) {
-    $version_to_use="v0.0.75"
+    $version_to_use="v0.0.76"
 }
 
 if ([string]::IsNullOrEmpty($INSTALL_FOLDER)) {


### PR DESCRIPTION
The purpose of this PR is to prepare the release of v0.0.76 of tipi/cmake-re.