### PR TITLE
install ca-certificates as a base package

### DIFF
--- a/install/container/centos.sh
+++ b/install/container/centos.sh
@@ -18,6 +18,7 @@ yum update -y && yum makecache \
   python3 \
   which \
   xz \
+  ca-certificates \
   bzip2
 
  # python3 which xz bzip2 are required for tipi build system (emsdk)
@@ -26,7 +27,6 @@ yum update -y && yum makecache \
 if [ "$TIPI_INSTALL_LEGACY_PACKAGES" = "ON" ]; then
  # INCLUDE+ common/Dockerfile.yum-install-required
   yum install -y systemd \
-    ca-certificates \
     openssh-clients \
     cmake3 \
     && yum groupinstall -y 'Development Tools' \

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -12,6 +12,7 @@ apt-get -y update && apt-get install -y \
   unzip \
   git \
   xz-utils \
+  ca-certificates \
   bzip2 
 
 source /etc/lsb-release
@@ -21,7 +22,6 @@ if [ "$TIPI_INSTALL_LEGACY_PACKAGES" = "ON" ]; then
   #INCLUDE+ common/Dockerfile.apt-install-required
   apt-get -y update && apt-get install -y \
     locales \
-    ca-certificates \
     build-essential \
     autotools-dev \
     autoconf \


### PR DESCRIPTION
The purpose of the PR is to install a new package within Docker as a base. This is necessary if you want to have a static tipi.