### PR TITLE
Support mirrored local installation

### DIFF
--- a/.github/workflows/check_container_build.yaml
+++ b/.github/workflows/check_container_build.yaml
@@ -157,6 +157,8 @@ jobs:
 
       - name: cmake-re offline mirror build
         run: |
+          set -euo pipefail
+
           # Manually copy our installs script to test the current version
           TOOLS_MIRROR_FOLDER=$PWD/local_tipi_install_mirrror/
           mkdir -p $TOOLS_MIRROR_FOLDER
@@ -184,13 +186,12 @@ jobs:
 
           cat install/container/environments/linux-offline.pkr.js/linux-offline.Dockerfile
 
-          BUILD_CONTAINER_OUTPUT=$(awk '
-            /^### Build Container$/ { in_section=1; next }
-            in_section && /^```bash$/ { in_code=1; next }
-            in_code && /^```$/ { exit }
-            in_code { print } ' INSTALL_LOCAL_MIRROR.md | bash)
+          # build the container
+          docker build --platform linux/amd64 install/container/environments/linux-offline.pkr.js/ -f install/container/environments/linux-offline.pkr.js/linux-offline.Dockerfile -t linux-offline:latest --network=host
 
-          echo -n $BUILD_CONTAINER_OUTPUT
+          # stop the server once you're done
+          docker stop -t0 package-mirroring-example-server
+
 
   docker-build-linux-offline-almalinux-95:
     name: docker-build-linux-offline-almalinux-95
@@ -203,6 +204,8 @@ jobs:
 
       - name: cmake-re offline mirror build almalinux-95 
         run: |
+          set -euo pipefail
+
           # Manually copy our installs script to test the current version
           TOOLS_MIRROR_FOLDER=$PWD/local_tipi_install_mirrror/
           mkdir -p $TOOLS_MIRROR_FOLDER
@@ -228,10 +231,8 @@ jobs:
 
           cat install/container/environments/linux-offline-almalinux-95.pkr.js/linux-offline-almalinux-95.Dockerfile
 
-          BUILD_CONTAINER_OUTPUT=$(awk '
+          awk '
             /^### Build Container$/ { in_section=1; next }
             in_section && /^```bash$/ { in_code=1; next }
             in_code && /^```$/ { exit }
-            in_code { print } ' INSTALL_LOCAL_MIRROR.md | bash)
-
-          echo -n $BUILD_CONTAINER_OUTPUT
+            in_code { print } ' INSTALL_LOCAL_MIRROR.md | bash

--- a/.github/workflows/check_container_build.yaml
+++ b/.github/workflows/check_container_build.yaml
@@ -162,6 +162,9 @@ jobs:
           mkdir -p $TOOLS_MIRROR_FOLDER
           cp -v install/install_for_macos_linux.sh ${TOOLS_MIRROR_FOLDER}
           cp -v install/container/*.sh ${TOOLS_MIRROR_FOLDER}
+          
+          # Ubuntu Mode (our local copy will still be used as the script doesn't overwrite)
+          export TIPI_CONTAINER_INSTALL_SCRIPT=https://raw.githubusercontent.com/tipi-build/cli/master/install/container/ubuntu.sh
 
           DISTRO_DOWNLOAD_OUTPUT=$(awk '
             /^### Setup local mirror$/ { in_section=1; next }
@@ -189,4 +192,46 @@ jobs:
 
           echo -n $BUILD_CONTAINER_OUTPUT
 
+  docker-build-linux-offline-almalinux-95:
+    name: docker-build-linux-offline-almalinux-95
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+          submodules: true
 
+      - name: cmake-re offline mirror build almalinux-95 
+        run: |
+          # Manually copy our installs script to test the current version
+          TOOLS_MIRROR_FOLDER=$PWD/local_tipi_install_mirrror/
+          mkdir -p $TOOLS_MIRROR_FOLDER
+          cp -v install/install_for_macos_linux.sh ${TOOLS_MIRROR_FOLDER}
+          cp -v install/container/*.sh ${TOOLS_MIRROR_FOLDER}
+
+          # Centos / RHEL Mode (our local copy will still be used as the script doesn't overwrite)
+          export TIPI_CONTAINER_INSTALL_SCRIPT=https://raw.githubusercontent.com/tipi-build/cli/master/install/container/centos.sh
+
+          DISTRO_DOWNLOAD_OUTPUT=$(awk '
+            /^### Setup local mirror$/ { in_section=1; next }
+            in_section && /^```bash$/ { in_code=1; next }
+            in_code && /^```$/ { exit }
+            in_code { print } ' INSTALL_LOCAL_MIRROR.md | bash)
+
+          echo -n $DISTRO_DOWNLOAD_OUTPUT
+
+          # Patch the Dockerfile with ENV values from download_distro.sh output
+          DOCKERFILE=install/container/environments/linux-offline-almalinux-95.pkr.js/linux-offline-almalinux-95.Dockerfile
+          echo "$DISTRO_DOWNLOAD_OUTPUT" | grep '^\s*ENV ' | sed 's/^\s*//' | while IFS='=' read -r key value; do
+            sed -i "s|${key}=.*|${key}=${value}|" "$DOCKERFILE"
+          done
+
+          cat install/container/environments/linux-offline-almalinux-95.pkr.js/linux-offline-almalinux-95.Dockerfile
+
+          BUILD_CONTAINER_OUTPUT=$(awk '
+            /^### Build Container$/ { in_section=1; next }
+            in_section && /^```bash$/ { in_code=1; next }
+            in_code && /^```$/ { exit }
+            in_code { print } ' INSTALL_LOCAL_MIRROR.md | bash)
+
+          echo -n $BUILD_CONTAINER_OUTPUT

--- a/.github/workflows/check_container_build.yaml
+++ b/.github/workflows/check_container_build.yaml
@@ -132,3 +132,61 @@ jobs:
 
           bin/cmake-re -S install/container/ -DCMAKE_TOOLCHAIN_FILE=install/container/environments/linux-custom-almalinux-95.cmake -B build -vv
 
+
+  test-distro-downloader:
+    name: test-distro-downloader
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+          submodules: true
+      - name: Run download_distro.sh test suite
+        run: |
+          bash install/utils/distro-downloader/test_download_distro.sh
+
+
+  docker-build-linux-offline:
+    name: docker-build-linux-offline
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+          submodules: true
+
+      - name: cmake-re offline mirror build
+        run: |
+          # Manually copy our installs script to test the current version
+          TOOLS_MIRROR_FOLDER=$PWD/local_tipi_install_mirrror/
+          mkdir -p $TOOLS_MIRROR_FOLDER
+          cp -v install/install_for_macos_linux.sh ${TOOLS_MIRROR_FOLDER}
+          cp -v install/container/*.sh ${TOOLS_MIRROR_FOLDER}
+
+          DISTRO_DOWNLOAD_OUTPUT=$(awk '
+            /^### Setup local mirror$/ { in_section=1; next }
+            in_section && /^```bash$/ { in_code=1; next }
+            in_code && /^```$/ { exit }
+            in_code { print } ' INSTALL_LOCAL_MIRROR.md | bash)
+
+          echo -n $DISTRO_DOWNLOAD_OUTPUT
+
+
+
+          # Patch the Dockerfile with ENV values from download_distro.sh output
+          DOCKERFILE=install/container/environments/linux-offline.pkr.js/linux-offline.Dockerfile
+          echo "$DISTRO_DOWNLOAD_OUTPUT" | grep '^\s*ENV ' | sed 's/^\s*//' | while IFS='=' read -r key value; do
+            sed -i "s|${key}=.*|${key}=${value}|" "$DOCKERFILE"
+          done
+
+          cat install/container/environments/linux-offline.pkr.js/linux-offline.Dockerfile
+
+          BUILD_CONTAINER_OUTPUT=$(awk '
+            /^### Build Container$/ { in_section=1; next }
+            in_section && /^```bash$/ { in_code=1; next }
+            in_code && /^```$/ { exit }
+            in_code { print } ' INSTALL_LOCAL_MIRROR.md | bash)
+
+          echo -n $BUILD_CONTAINER_OUTPUT
+
+

--- a/INSTALL_LOCAL_MIRROR.md
+++ b/INSTALL_LOCAL_MIRROR.md
@@ -65,7 +65,7 @@ A locally usable version of TIPI_DISTRO_JSON can be downloaded with all the requ
     TIPI_DISTRO_MODE - (default: "default")
     TIPI_INSTALL_SOURCE - url to release package (default: latest from offical cmake-re release)
     TIPI_CLIENT_INSTALL_SCRIPT_SOURCE - url to client install script (default: latest from offical cmake-re release)
-    TIPI_CONTAINER_INSTALL_SCRIPT - url to container install script (default: latest from offical cmake-re release)
+    TIPI_CONTAINER_INSTALL_SCRIPT - url to container install script (default: centos.sh latest from offical cmake-re release)
 ```
 
 ## Working Example: Build a docker from an offline mirror
@@ -92,7 +92,7 @@ docker run --name package-mirroring-example-server -d --rm -v ${TOOLS_MIRROR_FOL
 ### Build Container
 ```bash
 # build the container
-docker build --platform linux/amd64 install/container/environments/linux-offline.pkr.js/ -f install/container/environments/linux-offline.pkr.js/linux-offline.Dockerfile -t linux-offline:latest --network=host
+docker build --platform linux/amd64 install/container/environments/linux-offline-almalinux-95.pkr.js/ -f install/container/environments/linux-offline-almalinux-95.pkr.js/linux-offline-almalinux-95.Dockerfile -t linux-offline-almalinux-95:latest --network=host
 
 # stop the server once you're done
 docker stop -t0 package-mirroring-example-server

--- a/INSTALL_LOCAL_MIRROR.md
+++ b/INSTALL_LOCAL_MIRROR.md
@@ -1,0 +1,99 @@
+# Providing a self-hosted installation mirror for `cmake-re`
+In some context it can be necessary to shield the installation from the internet and use a mirror instead in order to provide a fully 
+self-hosted installation from validated sources.
+
+The Install scripts provide customization points and a script is available to make a local copy of all required TIPI_DISTRO_JSON tooling.
+
+In short you will need to 
+1. run the distro-downloader tool to create a copy of distro.json that points to your local URLs
+2. Set the following variables during the docker build process : 
+  * `TIPI_DISTRO_JSON`
+  * `TIPI_DISTRO_JSON_SHA1`
+  * `TIPI_INSTALL_SOURCE`
+  * `TIPI_CLIENT_INSTALL_SCRIPT_SOURCE`
+  * `TIPI_UTIL_LINUX_SOURCES_MIRROR`
+
+More details and an example hereafter.
+
+## Note
+`TIPI_INSTALL_LEGACY_PACKAGES=ON` is not used in `cmake-re` and won't be supported by self-hosted installation, the LEGACY mode is only used in official tipi 
+dockers for backward compatibility reasons and is subject of being removed in the future.
+
+The `install/container/*.sh` containers initialization scripts provide customization points to perform the installation.
+
+## `install/container/centos.sh` customization point 
+
+- You have to configure a local yum mirror in the Docker image before running the script, as we install packages like openssh-server
+- `ENV TIPI_CLIENT_INSTALL_SCRIPT_SOURCE` `cmake-re` to override client install script URL (_i.e._ override for https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_macos_linux.sh)
+
+## `install/container/ubuntu.sh` customization point 
+- You have to configure a local apt mirror in the Docker image before running the script, as we install packages like openssh-server
+- `ENV TIPI_CLIENT_INSTALL_SCRIPT_SOURCE` `cmake-re` to override client install script URL (_i.e._ override for https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_macos_linux.sh)
+- `ENV UTIL_LINUX_SOURCES_MIRROR` For Ubuntu release 16.04 or older (_i.e_ override for https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.39/util-linux-2.39.tar.gz)
+
+## cmake-re installation Customization
+You will need to provide :
+- `ENV TIPI_INSTALL_SOURCE` (_i.e._ override for the cmake-re client binaries release package, override for https://github.com/tipi-build/cli/releases/download/v0.0.85/tipi-v0.0.85-linux-x86_64.zip)
+
+### Local Mirroring of `TIPI_DISTRO_JSON`, `TIPI_DISTRO_JSON_SHA1` 
+
+`cmake-re` requires default tooling to be present, a minimal distro.json should only include updated URLs to : 
+- environments
+- ssh-over-http-proxy
+- cmake
+- make
+- ninja
+- cmake-tipi-provider
+- reclient
+
+A locally usable version of TIPI_DISTRO_JSON can be downloaded with all the required tools the `install/utils/distro-downloader/download_distro.sh`, as expained in the next section.
+
+#### Generate a locally mirrored distro
+
+```bash
+  install/utils/distro-downloader/download_distro.sh - usage:
+
+  download_distro.sh <OUTPUT-DIR> <BASE_URL>
+  
+  OUTPUT-DIR
+    Where the distro.local.json will be generated and where all distro assets will be downloaded.
+  BASE_URL
+    Where the distro.local.json should download the distro assets in this network (_i.e. Package mirroring server url)
+
+  Supported Variables:
+    TIPI_DISTRO_JSON -  (default: latest from offical cmake-re release)
+    TIPI_DISTRO_MODE - (default: "default")
+    TIPI_INSTALL_SOURCE - url to release package (default: latest from offical cmake-re release)
+    TIPI_CLIENT_INSTALL_SCRIPT_SOURCE - url to client install script (default: latest from offical cmake-re release)
+    TIPI_CONTAINER_INSTALL_SCRIPT - url to container install script (default: latest from offical cmake-re release)
+```
+
+## Working Example: Build a docker from an offline mirror
+
+In order for this build to work, we will locally host the downloaded distro tools at `http://127.0.0.1:8080/tools/` using a lightweigth `httpd`. This URL will be accessible during the docker build phase, so that is what is being passed into the `install/utils/distro-downloader/download_distro.sh` script:
+
+### Setup local mirror
+```bash
+TOOLS_MIRROR_FOLDER=$PWD/local_tipi_install_mirrror/
+# Manually copy our installs script to test the current version
+#mkdir -p $TOOLS_MIRROR_FOLDER
+#cp -v install/install_for_macos_linux.sh ${TOOLS_MIRROR_FOLDER}
+#cp -v install/container/*.sh ${TOOLS_MIRROR_FOLDER}
+
+# Creating a distro.local.json with mirrored archives hosted at http://127.0.0.1:8080/ 
+export TIPI_DISTRO_PLATFORM=linux
+export PACKAGE_MIRROR_SERVER=http://127.0.0.1:8080/ # Pointing to the httpd local server for demo purposes
+install/utils/distro-downloader/download_distro.sh ${TOOLS_MIRROR_FOLDER} ${PACKAGE_MIRROR_SERVER}
+
+# Example mirror to serve the data (this would typically be your internal packages server) start the localhost http server
+docker run --name package-mirroring-example-server -d --rm -v ${TOOLS_MIRROR_FOLDER}:/www/ -p 127.0.0.1:8080:80 busybox busybox httpd -f -p 80 -h /www
+```
+
+### Build Container
+```bash
+# build the container
+docker build --platform linux/amd64 install/container/environments/linux-offline.pkr.js/ -f install/container/environments/linux-offline.pkr.js/linux-offline.Dockerfile -t linux-offline:latest --network=host
+
+# stop the server once you're done
+docker stop -t0 package-mirroring-example-server
+```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Available as command line tool or vscode plugin !
 
 Paste that in a Linux shell prompt or in a macOS Terminal.
 
+### Install from a self-hosted installation mirror setup without outbound internet access
+See [Providing a self-hosted installation mirror for `cmake-re`](./INSTALL_LOCAL_MIRROR.md)
+
 ### Install on Windows 10
 ```
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls, [Net.SecurityProtocolType]::Tls11, [Net.SecurityProtocolType]::Tls12, [Net.SecurityProtocolType]::Ssl3

--- a/install/container/centos.sh
+++ b/install/container/centos.sh
@@ -122,7 +122,8 @@ git config --system --add safe.directory "*"
 
 export TIPI_DISTRO_MODE=${TIPI_DISTRO_MODE:-default}
 export TIPI_ENV_WHITELIST=${TIPI_ENV_WHITELIST:-TIPI_INSTALL_SOURCE,TIPI_DISTRO_MODE,TIPI_DISTRO_JSON,TIPI_DISTRO_JSON_SHA1}
-su tipi -c "cd ~ && curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/v0.0.85/install/install_for_macos_linux.sh -o install_for_macos_linux.sh && /bin/bash install_for_macos_linux.sh"
+TIPI_CLIENT_INSTALL_SCRIPT_SOURCE=${TIPI_CLIENT_INSTALL_SCRIPT_SOURCE:-https://raw.githubusercontent.com/tipi-build/cli/v0.0.85/install/install_for_macos_linux.sh}
+su tipi -c "cd ~ && curl -fsSL ${TIPI_CLIENT_INSTALL_SCRIPT_SOURCE} -o install_for_macos_linux.sh && /bin/bash install_for_macos_linux.sh"
 
 rm -rf ./main \
   && rm -rf /usr/local/share/.tipi/downloads/* \

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -74,8 +74,8 @@ if [ ${DISTRIB_RELEASE_MAJOR} -le 16 ]; then
     && rm -rf /var/lib/apt/lists/*
 
 
-
-  wget https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.39/util-linux-2.39.tar.gz  \
+  TIPI_UTIL_LINUX_SOURCES_MIRROR=${TIPI_UTIL_LINUX_SOURCES_MIRROR:-https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.39/util-linux-2.39.tar.gz}
+  wget "${TIPI_UTIL_LINUX_SOURCES_MIRROR}" \
     && tar xvzf util-linux-2.39.tar.gz  \
     && cd util-linux-2.39/  \
     && ./configure \
@@ -164,6 +164,7 @@ git config --system --add safe.directory "*"
 
 export TIPI_DISTRO_MODE=${TIPI_DISTRO_MODE:-default}
 export TIPI_ENV_WHITELIST=${TIPI_ENV_WHITELIST:-TIPI_INSTALL_SOURCE,TIPI_DISTRO_MODE,TIPI_DISTRO_JSON,TIPI_DISTRO_JSON_SHA1}
+
 # INCLUDE+ common/Dockerfile.rustup
 if [ "$TIPI_INSTALL_LEGACY_PACKAGES" = "ON" ]; then
   su tipi -w ${TIPI_ENV_WHITELIST} -c "cd ~ && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup.sh && sh rustup.sh -v -y --no-modify-path"
@@ -171,7 +172,8 @@ if [ "$TIPI_INSTALL_LEGACY_PACKAGES" = "ON" ]; then
 fi
 
 # INCLUDE+ common/Dockerfile.install-tipi
-su tipi -c 'cd ~ && curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/v0.0.85/install/install_for_macos_linux.sh -o install_for_macos_linux.sh && /bin/bash install_for_macos_linux.sh'
+TIPI_CLIENT_INSTALL_SCRIPT_SOURCE=${TIPI_CLIENT_INSTALL_SCRIPT_SOURCE:-https://raw.githubusercontent.com/tipi-build/cli/v0.0.85/install/install_for_macos_linux.sh}
+su tipi -c "cd ~ && curl -fsSL ${TIPI_CLIENT_INSTALL_SCRIPT_SOURCE} -o install_for_macos_linux.sh && /bin/bash install_for_macos_linux.sh"
 
 rm -rf ./main \
   && rm -rf /usr/local/share/.tipi/downloads/* \

--- a/install/utils/distro-downloader/download_distro.sh
+++ b/install/utils/distro-downloader/download_distro.sh
@@ -18,7 +18,7 @@ echo """
     TIPI_DISTRO_MODE - (default: "default")
     TIPI_INSTALL_SOURCE - url to release package (default: latest from offical cmake-re release)
     TIPI_CLIENT_INSTALL_SCRIPT_SOURCE - url to client install script (default: latest from offical cmake-re release)
-    TIPI_CONTAINER_INSTALL_SCRIPT - url to container install script (default: ubuntu.sh latest from offical cmake-re release)
+    TIPI_CONTAINER_INSTALL_SCRIPT - url to container install script (default: centos.sh latest from offical cmake-re release)
 """
 exit 1
 fi
@@ -39,7 +39,7 @@ BASE_URL="${BASE_URL%/}" # drop any trailing slashes
 
 TIPI_INSTALL_SOURCE="${TIPI_INSTALL_SOURCE:-https://github.com/tipi-build/cli/releases/download/v0.0.85/tipi-v0.0.85-linux-x86_64.zip}"
 TIPI_CLIENT_INSTALL_SCRIPT_SOURCE="${TIPI_CLIENT_INSTALL_SCRIPT_SOURCE:-https://raw.githubusercontent.com/tipi-build/cli/refs/heads/master/install/install_for_macos_linux.sh}"
-TIPI_CONTAINER_INSTALL_SCRIPT="${TIPI_CONTAINER_INSTALL_SCRIPT:-https://raw.githubusercontent.com/tipi-build/cli/refs/heads/master/install/container/ubuntu.sh}"
+TIPI_CONTAINER_INSTALL_SCRIPT="${TIPI_CONTAINER_INSTALL_SCRIPT:-https://raw.githubusercontent.com/tipi-build/cli/master/install/container/centos.sh}"
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -288,7 +288,6 @@ echo """
 
   ARG DEBIAN_FRONTEND=noninteractive # avoid tzdata asking for configuration
   # Install tipi and cmake-re
-  RUN apt update -y && apt install -y curl gettext
   RUN curl -fsSL \${TIPI_CONTAINER_INSTALL_SCRIPT} -o cmake-re_container_install.sh && /bin/bash cmake-re_container_install.sh
   USER tipi
   WORKDIR /home/tipi

--- a/install/utils/distro-downloader/download_distro.sh
+++ b/install/utils/distro-downloader/download_distro.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+
+echo """
+  install/utils/distro-downloader/download_distro.sh - usage:
+
+  download_distro.sh <OUTPUT-DIR> <BASE_URL>
+  
+  OUTPUT-DIR
+    Where the distro.local.json will be generated and where all distro assets will be downloaded.
+  BASE_URL
+    Where the distro.local.json should download the distro assets in this network (_i.e. Package mirroring server url)
+
+  Supported Variables:
+    TIPI_DISTRO_JSON -  (default: latest from offical cmake-re release)
+    TIPI_DISTRO_MODE - (default: "default")
+    TIPI_INSTALL_SOURCE - url to release package (default: latest from offical cmake-re release)
+    TIPI_CLIENT_INSTALL_SCRIPT_SOURCE - url to client install script (default: latest from offical cmake-re release)
+    TIPI_CONTAINER_INSTALL_SCRIPT - url to container install script (default: ubuntu.sh latest from offical cmake-re release)
+"""
+exit 1
+fi
+
+DISTRO_URL="${TIPI_DISTRO_JSON:-https://raw.githubusercontent.com/tipi-build/distro/refs/heads/main/distro.json}"
+
+RAW_DIR=${1:-.}
+CLEANED_DIR=$(echo "$RAW_DIR" | tr -s '/')
+CLEANED_DIR="${CLEANED_DIR%/}"
+DISTRO_DOWNLOAD_OUTPUT_DIR=${CLEANED_DIR:-/}
+
+TOOLS_DIR="${DISTRO_DOWNLOAD_OUTPUT_DIR}/"
+DISTRO_JSON="${DISTRO_DOWNLOAD_OUTPUT_DIR}/distro.json"
+DISTRO_LOCAL="${TOOLS_DIR}/distro.local.json"
+
+BASE_URL=${2:-"file://${TOOLS_DIR}"}
+BASE_URL="${BASE_URL%/}" # drop any trailing slashes
+
+TIPI_INSTALL_SOURCE="${TIPI_INSTALL_SOURCE:-https://github.com/tipi-build/cli/releases/download/v0.0.85/tipi-v0.0.85-linux-x86_64.zip}"
+TIPI_CLIENT_INSTALL_SCRIPT_SOURCE="${TIPI_CLIENT_INSTALL_SCRIPT_SOURCE:-https://raw.githubusercontent.com/tipi-build/cli/refs/heads/master/install/install_for_macos_linux.sh}"
+TIPI_CONTAINER_INSTALL_SCRIPT="${TIPI_CONTAINER_INSTALL_SCRIPT:-https://raw.githubusercontent.com/tipi-build/cli/refs/heads/master/install/container/ubuntu.sh}"
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+red()   { printf '\033[0;31m%s\033[0m\n' "$*"; }
+green() { printf '\033[0;32m%s\033[0m\n' "$*"; }
+cyan()  { printf '\033[0;36m%s\033[0m\n' "$*"; }
+warn()  { printf '\033[0;33mWARN: %s\033[0m\n' "$*" >&2; }
+
+require() {
+  command -v "$1" &>/dev/null || { red "Required tool not found: $1"; exit 1; }
+}
+
+# ── pre-flight ────────────────────────────────────────────────────────────────
+
+require curl
+require jq
+
+mkdir -p "$TOOLS_DIR"
+
+# ── 1. Download distro.json ───────────────────────────────────────────────────
+
+cyan "==> Downloading distro.json from cmake-re at $DISTRO_URL..."
+curl -fsSL "$DISTRO_URL" -o "$DISTRO_JSON"
+green "    Saved to $DISTRO_JSON"
+
+# ── 2. Resolve mode filter (optional) ────────────────────────────────────────
+
+MODE="${TIPI_DISTRO_MODE:-default}"
+
+if [[ "$MODE" = "all" ]]; then
+  cyan "==> No TIPI_DISTRO_MODE set — downloading all tools"
+  MODE_TOOLS_JSON="null"
+  # Collect the tool names for this mode into a bash array
+  mapfile -t MODE_TOOLS < <(jq -r "$DISTRO_JSON")
+  cyan "==> Mode '$MODE' selected — filtering to: ${MODE_TOOLS[*]}"
+elif [[ -n "$MODE" ]] ; then
+  # Validate the mode exists in the JSON
+  mode_exists=$(jq -r --arg m "$MODE" 'if .modes[$m] then "yes" else "no" end' "$DISTRO_JSON")
+  if [[ "$mode_exists" != "yes" ]]; then
+    red "Error: mode '$MODE' not found in distro.json"
+    echo "Available modes: $(jq -r '.modes | keys | join(", ")' "$DISTRO_JSON")"
+    exit 1
+  fi
+
+  # Collect the tool names for this mode into a bash array
+  mapfile -t MODE_TOOLS < <(jq -r --arg m "$MODE" '.modes[$m][]' "$DISTRO_JSON")
+  cyan "==> Mode '$MODE' selected — filtering to: ${MODE_TOOLS[*]}"
+
+  # Build a jq-compatible JSON array of tool names for filtering
+  MODE_TOOLS_JSON=$(jq -n --argjson tools "$(printf '%s\n' "${MODE_TOOLS[@]}" | jq -R . | jq -s .)" '$tools')
+fi
+
+# ── 2b. Resolve platform filter (optional) ───────────────────────────────────
+
+PLATFORM="${TIPI_DISTRO_PLATFORM:-}"
+
+if [[ -n "$PLATFORM" ]]; then
+  cyan "==> Platform '$PLATFORM' selected — only '$PLATFORM' and 'all' platform entries will be downloaded"
+else
+  cyan "==> No TIPI_DISTRO_PLATFORM set — downloading all platforms (including 'all')"
+fi
+
+# ── 3. Collect URLs (filtered by mode and/or platform) ───────────────────────
+
+mapfile -t URLS < <(jq -r --argjson filter "$MODE_TOOLS_JSON" --arg platform "$PLATFORM" '
+  .distro[]
+  | select(
+      if $filter == null then true
+      else .name as $n | ($filter | index($n)) != null
+      end
+    )
+  | .platforms
+  | to_entries[]
+  | select(
+      # "all" platform entries are unconditionally included
+      .key == "all"
+      or
+      if $platform == "" then true
+      else .key == $platform
+      end
+    )
+  | .value
+  | to_entries[]
+  | .value.url
+  | select(. != null)
+' "$DISTRO_JSON")
+
+total="${#URLS[@]}"
+cyan "==> Found $total tool archive(s) to download"
+
+# ── 4. Download tool archives in parallel ────────────────────────────────────
+
+# Max simultaneous downloads (default 8, override with TIPI_DOWNLOAD_JOBS)
+MAX_JOBS="${TIPI_DOWNLOAD_JOBS:-8}"
+
+# Temp file to collect failures from subshells
+FAIL_LOG="$(mktemp)"
+trap 'rm -f "$FAIL_LOG"' EXIT
+
+# Semaphore: wait until fewer than MAX_JOBS background jobs are running
+_throttle() {
+  while (( $(jobs -rp | wc -l) >= MAX_JOBS )); do
+    wait -n 2>/dev/null || true
+  done
+}
+
+declare -A PIDS   # pid → filename, for result reporting
+
+# Also Download cmake-re and install scripts
+URLS+=("${TIPI_INSTALL_SOURCE}")
+URLS+=("${TIPI_CONTAINER_INSTALL_SCRIPT}")
+URLS+=("${TIPI_CLIENT_INSTALL_SCRIPT_SOURCE}")
+
+for url in "${URLS[@]}"; do
+  filename="$(basename "$url")"
+  dest="$TOOLS_DIR/$filename"
+
+  if [[ -f "$dest" ]]; then
+    echo "  [skip]     $filename  (already exists)"
+    continue
+  fi
+
+  _throttle
+  echo "  [start]    $filename"
+  (
+    if curl -fsSL --retry 3 --retry-delay 2 "$url" -o "$dest"; then
+      echo "  [done]     $filename"
+    else
+      warn "Failed to download: $url"
+      rm -f "$dest"
+      echo "$url" >> "$FAIL_LOG"
+    fi
+  ) &
+  PIDS[$!]="$filename"
+done
+
+# Wait for all remaining background jobs to finish
+wait
+
+failed=$(wc -l < "$FAIL_LOG" | tr -d ' ')
+if (( failed > 0 )); then
+  warn "$failed download(s) failed:"
+  while IFS= read -r url; do
+    warn "  $url"
+  done < "$FAIL_LOG"
+fi
+
+# ── 5. Rewrite distro.json with formatted URLs (strip to mode if set) ────────
+
+cyan "==> Writing $DISTRO_LOCAL with rewritten URLs..."
+
+jq --arg base_url "$BASE_URL" --argjson filter "$MODE_TOOLS_JSON" --arg platform "$PLATFORM" '
+  # Keep only the relevant mode entry (or all modes if no filter)
+  .modes |= (
+    if $filter == null then .
+    else
+      to_entries
+      | map(select(
+          .value | (map(. as $t | ($filter | index($t)) != null) | any)
+        ))
+      | from_entries
+    end
+  )
+  |
+  # Strip distro entries not in the mode filter
+  .distro |= map(
+    select(
+      if $filter == null then true
+      else .name as $n | ($filter | index($n)) != null
+      end
+    )
+  )
+  |
+  # Strip platforms not matching the platform filter.
+  # "all" platform entries are unconditionally kept — they are platform-agnostic.
+  .distro[] |= (
+    .platforms |= with_entries(
+      select(
+        .key == "all"
+        or
+        if $platform == "" then true
+        else .key == $platform
+        end
+      )
+    )
+  )
+  |
+  # Rewrite all url fields using the normalized base_url
+  .distro[] |= (
+    .platforms |= with_entries(
+      .value |= with_entries(
+        if (.value | type) == "object" and .value.url then
+          .value.url |= ($base_url + "/" + (. | split("/") | last))
+        else
+          .
+        end
+      )
+    )
+  )
+' "$DISTRO_JSON" > "$DISTRO_LOCAL"
+
+rm "$DISTRO_JSON"
+
+# Creating sha1sum named install scripts to invalidate Docker build cache
+TIPI_CLIENT_INSTALL_SCRIPT_SOURCE_PATH=$TOOLS_DIR/$(basename "$TIPI_CLIENT_INSTALL_SCRIPT_SOURCE")
+TIPI_CONTAINER_INSTALL_SCRIPT_PATH=$TOOLS_DIR/$(basename "$TIPI_CONTAINER_INSTALL_SCRIPT")
+#TIPI_UTIL_LINUX_SOURCES_MIRROR_PATH=$TOOLS_DIR/$(basename "$TIPI_UTIL_LINUX_SOURCES_MIRROR")
+
+TIPI_CLIENT_INSTALL_SCRIPT_SOURCE_SHA1SUM=$(sha1sum ${TIPI_CLIENT_INSTALL_SCRIPT_SOURCE_PATH} | cut -d ' ' -f 1)
+TIPI_CONTAINER_INSTALL_SCRIPT_SHA1SUM=$(sha1sum ${TIPI_CONTAINER_INSTALL_SCRIPT_PATH} | cut -d ' ' -f 1)
+
+mv $TIPI_CLIENT_INSTALL_SCRIPT_SOURCE_PATH "$TOOLS_DIR/$TIPI_CLIENT_INSTALL_SCRIPT_SOURCE_SHA1SUM-$(basename "$TIPI_CLIENT_INSTALL_SCRIPT_SOURCE")"
+mv $TIPI_CONTAINER_INSTALL_SCRIPT_PATH "$TOOLS_DIR/$TIPI_CONTAINER_INSTALL_SCRIPT_SHA1SUM-$(basename "$TIPI_CONTAINER_INSTALL_SCRIPT")"
+
+# Moving release binary as release name independent to ensure linux-offline.Dockerfile is an up-to-date example
+rm -f $TOOLS_DIR/tipi-linux.zip && mv $TOOLS_DIR/$(basename "$TIPI_INSTALL_SOURCE") $TOOLS_DIR/tipi-linux.zip
+TIPI_INSTALL_SOURCE=${BASE_URL}/tipi-linux.zip
+
+TIPI_DISTRO_JSON_SHA1=$(sha1sum ${DISTRO_LOCAL} | cut -d ' ' -f 1)
+
+green "==> Done!"
+echo ""
+echo "  Original distro :  $DISTRO_JSON, removed."
+echo "  Local TIPI_DISTRO_JSON :  $DISTRO_LOCAL"
+echo "  Local TIPI_DISTRO_JSON_SHA1   :  $TIPI_DISTRO_JSON_SHA1"
+echo "  cmake-re release:  $(basename "$TIPI_INSTALL_SOURCE")"
+echo "  Distro archive   :  $TOOLS_DIR"
+echo "  Base URL        :  $BASE_URL"
+if [[ -n "$MODE" ]]; then
+  echo "  Mode filter     :  $MODE  (${#MODE_TOOLS[@]} tools)"
+fi
+if [[ -n "$PLATFORM" ]]; then
+  echo "  Platform filter :  $PLATFORM  (+ 'all')"
+fi
+echo ""
+echo "Use '$DISTRO_LOCAL' in your cmake-re configuration to point at your local TIPI_DISTRO_JSON hosting."
+echo "Patch this in your Dockerfile : "
+echo """
+  ENV TIPI_DISTRO_MODE=${MODE}
+  ENV TIPI_DISTRO_JSON=${BASE_URL}/distro.local.json
+  ENV TIPI_DISTRO_JSON_SHA1=${TIPI_DISTRO_JSON_SHA1}
+  ENV TIPI_INSTALL_SOURCE=${TIPI_INSTALL_SOURCE}
+  ENV TIPI_CLIENT_INSTALL_SCRIPT_SOURCE=${BASE_URL}/$TIPI_CLIENT_INSTALL_SCRIPT_SOURCE_SHA1SUM-$(basename "$TIPI_CLIENT_INSTALL_SCRIPT_SOURCE")
+  ENV TIPI_UTIL_LINUX_SOURCES_MIRROR=${BASE_URL}/util-linux-2.39.tar.gz
+  ENV TIPI_CONTAINER_INSTALL_SCRIPT=${BASE_URL}/$TIPI_CONTAINER_INSTALL_SCRIPT_SHA1SUM-$(basename "$TIPI_CONTAINER_INSTALL_SCRIPT")
+
+  ARG DEBIAN_FRONTEND=noninteractive # avoid tzdata asking for configuration
+  # Install tipi and cmake-re
+  RUN apt update -y && apt install -y curl gettext
+  RUN curl -fsSL \${TIPI_CONTAINER_INSTALL_SCRIPT} -o cmake-re_container_install.sh && /bin/bash cmake-re_container_install.sh
+  USER tipi
+  WORKDIR /home/tipi
+  EXPOSE 22
+"""

--- a/install/utils/distro-downloader/test_download_distro.sh
+++ b/install/utils/distro-downloader/test_download_distro.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# Test suite for download_distro.sh
+# Downloads are intercepted — no real archives are fetched.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAIN_SCRIPT="$SCRIPT_DIR/download_distro.sh"
+
+# ── colour helpers ────────────────────────────────────────────────────────────
+red()    { printf '\033[0;31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[0;32m%s\033[0m\n' "$*"; }
+cyan()   { printf '\033[0;36m%s\033[0m\n' "$*"; }
+
+PASS=0; FAIL=0
+
+assert() {
+  local desc="$1"; shift
+  if "$@" &>/dev/null; then
+    green "  [PASS] $desc"
+    (( PASS++ )) || true
+  else
+    red "  [FAIL] $desc"
+    (( FAIL++ )) || true
+  fi
+}
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    green "  [PASS] $desc"
+    (( PASS++ )) || true
+  else
+    red "  [FAIL] $desc"
+    red "         expected: $expected"
+    red "         actual  : $actual"
+    (( FAIL++ )) || true
+  fi
+}
+
+# ── setup: temp working directory ─────────────────────────────────────────────
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# ── mock curl factory ─────────────────────────────────────────────────────────
+# Installs a fake curl into a given bin dir.
+# The fake curl fetches the real distro.json once; all other downloads are stubs.
+setup_mock_curl() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+  cat > "$bin_dir/curl" <<'MOCK'
+#!/usr/bin/env bash
+output_file=""
+url=""
+args=("$@")
+i=0
+while (( i < ${#args[@]} )); do
+  case "${args[$i]}" in
+    -o) (( i++ )); output_file="${args[$i]}" ;;
+    http*) url="${args[$i]}" ;;
+  esac
+  (( i++ )) || true
+done
+REAL_URL="https://raw.githubusercontent.com/tipi-build/distro/refs/heads/main/distro.json"
+if [[ "$url" == "$REAL_URL" ]]; then
+  /usr/bin/curl -fsSL "$url" -o "$output_file"
+else
+  touch "$output_file"
+fi
+MOCK
+  chmod +x "$bin_dir/curl"
+}
+
+# ── helper: run script in isolated subdir ─────────────────────────────────────
+# Usage: run_scenario <label> [KEY=VAL ...]
+# After the call, use $WORKDIR/<label> for assertions — nothing is printed to stdout.
+run_scenario() {
+  local label="$1"; shift   # scenario name
+  local subdir="$WORKDIR/$label"
+  mkdir -p "$subdir"
+  local mock_bin="$subdir/.mockbin"
+  setup_mock_curl "$mock_bin"
+  (
+    export PATH="$mock_bin:$PATH"
+    cd "$subdir"
+    env "$@" bash "$MAIN_SCRIPT" .
+  )
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Scenario 1 — mode=default, no platform filter
+# ═══════════════════════════════════════════════════════════════════════════════
+cyan ""
+cyan "══════════════════════════════════════════════════"
+cyan " Scenario 1: TIPI_DISTRO_MODE=default (all platforms)"
+cyan "══════════════════════════════════════════════════"
+run_scenario "s1" TIPI_DISTRO_MODE=default
+S1="$WORKDIR/s1"
+
+EXPECTED_TOOLS=(openssh environments ssh-over-http-proxy cmake make ninja cmake-tipi-provider reclient)
+
+cyan "--- assertions ---"
+
+assert "S1: distro.local.json created" test -f "$S1/distro.local.json"
+assert "S1: distro.local.json is valid JSON" jq empty "$S1/distro.local.json"
+
+actual_tools=$(jq -r '[.distro[].name] | sort | join(" ")' "$S1/distro.local.json")
+expected_sorted=$(printf '%s\n' "${EXPECTED_TOOLS[@]}" | sort | tr '\n' ' ' | sed 's/ $//')
+assert_eq "S1: exactly the default-mode tools are present" "$expected_sorted" "$actual_tools"
+
+non_file=$(jq -r '[.distro[].platforms | to_entries[] | .value | to_entries[] | .value.url | select(. != null and (startswith("file://") | not))] | length' "$S1/distro.local.json")
+assert_eq "S1: all URLs use file:// scheme" "0" "$non_file"
+
+mode_count=$(jq '.modes | length' "$S1/distro.local.json")
+assert_eq "S1: modes stripped to 1 entry" "1" "$mode_count"
+
+# All three platforms should still be present (no platform filter)
+cmake_platforms=$(jq -r '.distro[] | select(.name=="cmake") | .platforms | keys | sort | join(" ")' "$S1/distro.local.json")
+assert_eq "S1: cmake retains all platforms when no filter" "linux macos windows" "$cmake_platforms"
+
+# "all" platform tools must be present even when no platform filter is set
+env_platforms=$(jq -r '.distro[] | select(.name=="environments") | .platforms | keys | join(" ")' "$S1/distro.local.json")
+assert_eq "S1: 'all'-platform tool (environments) is present with no platform filter" "all" "$env_platforms"
+
+cmake_tipi_platforms=$(jq -r '.distro[] | select(.name=="cmake-tipi-provider") | .platforms | keys | join(" ")' "$S1/distro.local.json")
+assert_eq "S1: 'all'-platform tool (cmake-tipi-provider) is present with no platform filter" "all" "$cmake_tipi_platforms"
+
+for tool in perl python nodejs clang go; do
+  count=$(jq --arg t "$tool" '[.distro[].name] | index($t)' "$S1/distro.local.json")
+  assert_eq "S1: '$tool' absent (not in default mode)" "null" "$count"
+done
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Scenario 2 — mode=default + platform=linux
+# ═══════════════════════════════════════════════════════════════════════════════
+cyan ""
+cyan "══════════════════════════════════════════════════"
+cyan " Scenario 2: TIPI_DISTRO_MODE=default + TIPI_DISTRO_PLATFORM=linux"
+cyan "══════════════════════════════════════════════════"
+run_scenario "s2" TIPI_DISTRO_MODE=default TIPI_DISTRO_PLATFORM=linux
+S2="$WORKDIR/s2"
+
+cyan "--- assertions ---"
+
+assert "S2: distro.local.json created" test -f "$S2/distro.local.json"
+assert "S2: distro.local.json is valid JSON" jq empty "$S2/distro.local.json"
+
+# Only linux and "all" platforms should appear
+bad_platforms=$(jq -r '[
+  .distro[].platforms | keys[]
+  | select(. != "linux" and . != "all")
+] | length' "$S2/distro.local.json")
+assert_eq "S2: no macos/windows platform entries remain" "0" "$bad_platforms"
+
+# cmake has linux — must be present
+cmake_platforms=$(jq -r '.distro[] | select(.name=="cmake") | .platforms | keys | join(" ")' "$S2/distro.local.json")
+assert_eq "S2: cmake keeps only linux platform" "linux" "$cmake_platforms"
+
+# environments has only "all" — must still be present
+env_platforms=$(jq -r '.distro[] | select(.name=="environments") | .platforms | keys | join(" ")' "$S2/distro.local.json")
+assert_eq "S2: environments keeps 'all' platform" "all" "$env_platforms"
+
+non_file2=$(jq -r '[.distro[].platforms | to_entries[] | .value | to_entries[] | .value.url | select(. != null and (startswith("file://") | not))] | length' "$S2/distro.local.json")
+assert_eq "S2: all URLs use file:// scheme" "0" "$non_file2"
+
+# File count matches URL count in the stripped JSON
+downloaded=$(ls "$S2/" | wc -l | tr -d ' ')
+expected_urls=$(jq -r '[.distro[].platforms | to_entries[] | .value | to_entries[] | .value.url | select(. != null)] | length' "$S2/distro.local.json")
+# 4 additional hardcoded files:  install_for_macos_linux.sh, ubuntu.sh/centos.sh, tipi-v0.0.85-linux-x86_64.zip  + distro.local.json
+expected_urls=$((expected_urls + 4 ))
+assert_eq "S2: downloaded file count matches URL count in distro.local.json" "$expected_urls" "$downloaded"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Scenario 3 — platform=linux only (no mode filter)
+# ═══════════════════════════════════════════════════════════════════════════════
+cyan ""
+cyan "══════════════════════════════════════════════════"
+cyan " Scenario 3: TIPI_DISTRO_PLATFORM=linux (all tools)"
+cyan "══════════════════════════════════════════════════"
+run_scenario "s3" TIPI_DISTRO_PLATFORM=linux TIPI_DISTRO_MODE=all
+S3="$WORKDIR/s3"
+
+cyan "--- assertions ---"
+
+assert "S3: distro.local.json created" test -f "$S3/distro.local.json"
+assert "S3: distro.local.json is valid JSON" jq empty "$S3/distro.local.json"
+
+bad_platforms3=$(jq -r '[
+  .distro[].platforms | keys[]
+  | select(. != "linux" and . != "all")
+] | length' "$S3/distro.local.json")
+assert_eq "S3: no macos/windows entries in any tool" "0" "$bad_platforms3"
+
+# "all" platform tools must still appear even when platform=linux is set
+env_platforms3=$(jq -r '.distro[] | select(.name=="environments") | .platforms | keys | join(" ")' "$S3/distro.local.json")
+assert_eq "S3: 'all'-platform tool (environments) is present with platform=linux" "all" "$env_platforms3"
+
+# All tools (not just default mode) should be present
+tool_count=$(jq '[.distro[].name] | length' "$S3/distro.local.json")
+all_tool_count=$(curl -fsSL "https://raw.githubusercontent.com/tipi-build/distro/refs/heads/main/distro.json" 2>/dev/null | jq '[.distro[].name] | length')
+assert_eq "S3: all tools present (no mode filter)" "$all_tool_count" "$tool_count"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Scenario 4 — arbitrary / unknown platform is accepted
+# ═══════════════════════════════════════════════════════════════════════════════
+cyan ""
+cyan "══════════════════════════════════════════════════"
+cyan " Scenario 4: arbitrary platform (freebsd) is accepted"
+cyan "══════════════════════════════════════════════════"
+run_scenario "s4" TIPI_DISTRO_PLATFORM=arm64
+S4="$WORKDIR/s4"
+
+cyan "--- assertions ---"
+
+assert "S4: distro.local.json created"       test -f "$S4/distro.local.json"
+assert "S4: distro.local.json is valid JSON" jq empty "$S4/distro.local.json"
+
+# No freebsd-specific entries exist in the real distro.json, so only "all"
+# platform tools should remain
+bad_platforms4=$(jq -r '[
+  .distro[].platforms | keys[]
+  | select(. != "freebsd" and . != "all")
+] | length' "$S4/distro.local.json")
+assert_eq "S4: no entries for other platforms (only freebsd + all)" "0" "$bad_platforms4"
+
+# "all" platform tools must still be present
+env_platforms4=$(jq -r '.distro[] | select(.name=="environments") | .platforms | keys | join(" ")' "$S4/distro.local.json")
+assert_eq "S4: 'all'-platform tool (environments) present for unknown platform" "all" "$env_platforms4"
+
+# ── summary ───────────────────────────────────────────────────────────────────
+echo ""
+cyan "══════════════════════════════════════════════════"
+cyan " Results: $PASS passed, $FAIL failed"
+cyan "══════════════════════════════════════════════════"
+echo ""
+if (( FAIL > 0 )); then
+  red "Some tests failed."
+  exit 1
+else
+  green "All tests passed."
+fi


### PR DESCRIPTION
This is a PR providing new scripts to help user mirror locally / in their local network all required packages for installation without requiring outbound internet access during installation.

### Dependent PR
- [x] https://github.com/tipi-build/environments/pull/52

Close tipi-build/specs-cmake-re#489