### PR TITLE
🚀 Release v0.0.86

### DIFF
--- a/.github/workflows/check_container_build.yaml
+++ b/.github/workflows/check_container_build.yaml
@@ -18,7 +18,7 @@ env:
   TIPI_DISTRO_MODE: default
   TIPI_DISTRO_JSON_URL: https://raw.githubusercontent.com/tipi-build/distro/442a423e65f09ab0290609bc15f382585e89103e/distro.json
   TIPI_DISTRO_JSON_SHA1: 39ace975db0eb1f5a02318130fb425d21731ea5c
-  version_in_development: v0.0.85
+  version_in_development: v0.0.86
   TIPI_ACCESS_TOKEN: ${{ secrets.CLI_TIPI_TEST_USER_TIPI_ACCESS_TOKEN }}
   TIPI_REFRESH_TOKEN: ${{ secrets.CLI_TIPI_TEST_USER_TIPI_REFRESH_TOKEN }}
   TIPI_VAULT_PASSPHRASE: ${{ secrets.CLI_TIPI_TEST_USER_TIPI_VAULT_PASSPHRASE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # tipi.build cli : CHANGELOG
 
+## v0.0.86 - Tough Tamarin 🐒
+
+### Bug Fix
+
+- Fix `git_gc` lock acquisition failing on submodule paths where `.git` is a gitlink file instead of a directory (TIPI-1795)
+- Fix nested submodule path duplication during mirroring submodule (TIPI-1778)
+- Fix distro-less mode (`TIPI_DISTRO_MODE=none`) failing to find `rewrapper` and `bootstrap` in `--distributed` builds (TIPI-1734)
+
+tipi-src: 5658a73f4555d2ed851d3a02f17a2ee2bd538961
+
+### Archives Checksums
+tipi-v0.0.86-windows-win64.zip:5B5C21A7FFE0C7C20F8CC462D2E30D5A4930FB8E
+tipi-v0.0.86-linux-x86_64.zip:9C2E0B7AD26B760E8D63A2855031C3F4A7C65FA5
+tipi-v0.0.86-macOS.zip:3FE9AA364FE49CD6E3B17859CD4E52D8039E1C26
+
 ## v0.0.85 - Sunny Seal ☀️🦭
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # tipi.build cli : CHANGELOG
 
-## v0.0.86 - Tough Tamarin 🐒
+## v0.0.86 - Tonic Tamarin 🐒
+
+### Features
+
+- 🆕 Tooling enabling easier fully mirrored offline installation of cmake-re without dependency to github.com (TIPI-1807) 
+  - [Usage instructions](https://github.com/tipi-build/cli/blob/master/INSTALL_LOCAL_MIRROR.md)
 
 ### Bug Fix
 

--- a/INSTALL_LOCAL_MIRROR.md
+++ b/INSTALL_LOCAL_MIRROR.md
@@ -33,7 +33,7 @@ The `install/container/*.sh` containers initialization scripts provide customiza
 
 ## cmake-re installation Customization
 You will need to provide :
-- `ENV TIPI_INSTALL_SOURCE` (_i.e._ override for the cmake-re client binaries release package, override for https://github.com/tipi-build/cli/releases/download/v0.0.85/tipi-v0.0.85-linux-x86_64.zip)
+- `ENV TIPI_INSTALL_SOURCE` (_i.e._ override for the cmake-re client binaries release package, override for https://github.com/tipi-build/cli/releases/download/v0.0.86/tipi-v0.0.86-linux-x86_64.zip)
 
 ### Local Mirroring of `TIPI_DISTRO_JSON`, `TIPI_DISTRO_JSON_SHA1` 
 

--- a/install/container/centos.sh
+++ b/install/container/centos.sh
@@ -122,7 +122,7 @@ git config --system --add safe.directory "*"
 
 export TIPI_DISTRO_MODE=${TIPI_DISTRO_MODE:-default}
 export TIPI_ENV_WHITELIST=${TIPI_ENV_WHITELIST:-TIPI_INSTALL_SOURCE,TIPI_DISTRO_MODE,TIPI_DISTRO_JSON,TIPI_DISTRO_JSON_SHA1}
-TIPI_CLIENT_INSTALL_SCRIPT_SOURCE=${TIPI_CLIENT_INSTALL_SCRIPT_SOURCE:-https://raw.githubusercontent.com/tipi-build/cli/v0.0.85/install/install_for_macos_linux.sh}
+TIPI_CLIENT_INSTALL_SCRIPT_SOURCE=${TIPI_CLIENT_INSTALL_SCRIPT_SOURCE:-https://raw.githubusercontent.com/tipi-build/cli/v0.0.86/install/install_for_macos_linux.sh}
 su tipi -c "cd ~ && curl -fsSL ${TIPI_CLIENT_INSTALL_SCRIPT_SOURCE} -o install_for_macos_linux.sh && /bin/bash install_for_macos_linux.sh"
 
 rm -rf ./main \

--- a/install/container/ubuntu.sh
+++ b/install/container/ubuntu.sh
@@ -172,7 +172,7 @@ if [ "$TIPI_INSTALL_LEGACY_PACKAGES" = "ON" ]; then
 fi
 
 # INCLUDE+ common/Dockerfile.install-tipi
-TIPI_CLIENT_INSTALL_SCRIPT_SOURCE=${TIPI_CLIENT_INSTALL_SCRIPT_SOURCE:-https://raw.githubusercontent.com/tipi-build/cli/v0.0.85/install/install_for_macos_linux.sh}
+TIPI_CLIENT_INSTALL_SCRIPT_SOURCE=${TIPI_CLIENT_INSTALL_SCRIPT_SOURCE:-https://raw.githubusercontent.com/tipi-build/cli/v0.0.86/install/install_for_macos_linux.sh}
 su tipi -c "cd ~ && curl -fsSL ${TIPI_CLIENT_INSTALL_SCRIPT_SOURCE} -o install_for_macos_linux.sh && /bin/bash install_for_macos_linux.sh"
 
 rm -rf ./main \

--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -41,7 +41,7 @@ request_install_permission() {
 # impl.
 ### 
 
-VERSION="${TIPI_INSTALL_VERSION:-v0.0.85}"
+VERSION="${TIPI_INSTALL_VERSION:-v0.0.86}"
 INSTALL_FOLDER=/usr/local
 
 if [[ -z "${TIPI_INSTALL_SOURCE}" ]]; then

--- a/install/install_for_windows.ps1
+++ b/install/install_for_windows.ps1
@@ -58,7 +58,7 @@ if([bool]::TryParse($env:TIPI_INSTALL_SYSTEM, [ref]$system_install)) {
 }
 
 if ([string]::IsNullOrEmpty($version_to_use)) {
-    $version_to_use="v0.0.85"
+    $version_to_use="v0.0.86"
 }
 
 if ([string]::IsNullOrEmpty($INSTALL_FOLDER)) {

--- a/install/utils/distro-downloader/download_distro.sh
+++ b/install/utils/distro-downloader/download_distro.sh
@@ -37,7 +37,7 @@ DISTRO_LOCAL="${TOOLS_DIR}/distro.local.json"
 BASE_URL=${2:-"file://${TOOLS_DIR}"}
 BASE_URL="${BASE_URL%/}" # drop any trailing slashes
 
-TIPI_INSTALL_SOURCE="${TIPI_INSTALL_SOURCE:-https://github.com/tipi-build/cli/releases/download/v0.0.85/tipi-v0.0.85-linux-x86_64.zip}"
+TIPI_INSTALL_SOURCE="${TIPI_INSTALL_SOURCE:-https://github.com/tipi-build/cli/releases/download/v0.0.86/tipi-v0.0.86-linux-x86_64.zip}"
 TIPI_CLIENT_INSTALL_SCRIPT_SOURCE="${TIPI_CLIENT_INSTALL_SCRIPT_SOURCE:-https://raw.githubusercontent.com/tipi-build/cli/refs/heads/master/install/install_for_macos_linux.sh}"
 TIPI_CONTAINER_INSTALL_SCRIPT="${TIPI_CONTAINER_INSTALL_SCRIPT:-https://raw.githubusercontent.com/tipi-build/cli/master/install/container/centos.sh}"
 


### PR DESCRIPTION
The purpose of this PR is to prepare the release of v0.0.86 of tipi/cmake-re.